### PR TITLE
Python Back-end does not set mime header on responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN python setup.py bdist_wheel -d wheel
 
 FROM python:3-slim
 WORKDIR /opt/warp
+RUN apt-get update && \
+  apt-get install --yes mime-support  && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN \
     --mount=type=bind,from=compile-image,source=/opt/warp/debs,target=./debs \

--- a/res/warp_uwsgi.ini
+++ b/res/warp_uwsgi.ini
@@ -1,4 +1,5 @@
 [uwsgi]
+mimefile = /etc/mime.types
 
 socket = 0.0.0.0:8000
 


### PR DESCRIPTION
Hi.
  Added support to mime types in uwsgi docker in order to get proper http header on responses.
