### PR TITLE
:pencil: Applied isort and black on code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Build docker image and run a smoke test
       id: build_docker_image
       run: |
-        docker build -f Dockerfile_DEV -t warp:latest .
+        docker build -f Dockerfile -t warp:latest .
         docker run -d -p 5000:5000 --name warp warp:latest
         sleep 10
         docker rm -f warp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Build docker image and run a smoke test
       id: build_docker_image
       run: |
-        docker build -f Dockerfile -t warp:latest .
+        DOCKER_BUILDKIT=1 docker build -f Dockerfile -t warp:latest .
         docker run -d -p 5000:5000 --name warp warp:latest
         sleep 10
         docker rm -f warp

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,16 @@
 from setuptools import setup, find_packages
-import subprocess
 
 version = "2.0"
 
+
 def getRequirements():
-    with open('requirements.txt', 'r') as file:
+    with open("requirements.txt", "r") as file:
         return file.readlines()
 
     return []
 
-#def getVersion():
+
+# def getVersion():
 #
 #    subprocess.run(['git','update-index','--refresh'], \
 #        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -26,9 +27,9 @@ def getRequirements():
 
 
 setup(
-    name='warp',
+    name="warp",
     packages=find_packages(),
-    version='2.0.dev1',
+    version="2.0.dev1",
     include_package_data=True,
     install_requires=getRequirements(),
 )

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -1,7 +1,6 @@
 import flask
-from werkzeug.middleware.proxy_fix import ProxyFix
 
-from warp.config import *
+from .config import initConfig
 
 
 def create_app():

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -1,31 +1,35 @@
 import flask
 from werkzeug.middleware.proxy_fix import ProxyFix
+
 from warp.config import *
 
-def create_app():
 
+def create_app():
     app = flask.Flask(__name__)
 
     initConfig(app)
 
     from . import db
+
     db.init(app)
 
     from . import view
+
     app.register_blueprint(view.bp)
 
     from . import xhr
-    app.register_blueprint(xhr.bp, url_prefix='/xhr')
 
-    from . import auth
-    from . import auth_mellon
-    from . import auth_ldap
-    if 'AUTH_MELLON' in app.config \
-       and 'MELLON_ENDPOINT' in app.config \
-       and app.config['AUTH_MELLON']:
+    app.register_blueprint(xhr.bp, url_prefix="/xhr")
+
+    from . import auth, auth_ldap, auth_mellon
+
+    if (
+        "AUTH_MELLON" in app.config
+        and "MELLON_ENDPOINT" in app.config
+        and app.config["AUTH_MELLON"]
+    ):
         app.register_blueprint(auth_mellon.bp)
-    elif 'AUTH_LDAP' in app.config \
-       and app.config['AUTH_LDAP']:
+    elif "AUTH_LDAP" in app.config and app.config["AUTH_LDAP"]:
         app.register_blueprint(auth_ldap.bp)
     else:
         app.register_blueprint(auth.bp)

--- a/warp/auth.py
+++ b/warp/auth.py
@@ -1,9 +1,8 @@
 import flask
 from werkzeug.security import check_password_hash
 
-from warp.db import *
-
 from . import utils
+from .db import ACCOUNT_TYPE_ADMIN, ACCOUNT_TYPE_BLOCKED, ACCOUNT_TYPE_GROUP, Users
 
 bp = flask.Blueprint("auth", __name__)
 

--- a/warp/auth.py
+++ b/warp/auth.py
@@ -1,9 +1,11 @@
 import flask
 from werkzeug.security import check_password_hash
+
 from warp.db import *
+
 from . import utils
 
-bp = flask.Blueprint('auth', __name__)
+bp = flask.Blueprint("auth", __name__)
 
 # NOTE:
 # In this module I don't use decorators (route and before_app_request) to register
@@ -15,75 +17,74 @@ bp = flask.Blueprint('auth', __name__)
 
 
 def login():
-
     # clear session to force re-login
     # we should not do it via logout as in case of SSO
     # we will logout from SSO, and we just want to issue
     # an extra request to SSO
     flask.session.clear()
 
-    if flask.request.method == 'POST':
-
-        u = flask.request.form.get('login')
-        p =  flask.request.form.get('password')
+    if flask.request.method == "POST":
+        u = flask.request.form.get("login")
+        p = flask.request.form.get("password")
 
         c = Users.select().where((Users.login == u) & (Users.account_type != ACCOUNT_TYPE_GROUP))
 
-        if len(c) == 1 \
-           and c[0]['password'] is not None \
-           and check_password_hash(c[0]['password'],p):
-
-            account_type = c[0]['account_type']
+        if (
+            len(c) == 1
+            and c[0]["password"] is not None
+            and check_password_hash(c[0]["password"], p)
+        ):
+            account_type = c[0]["account_type"]
 
             if account_type == ACCOUNT_TYPE_BLOCKED:
                 flask.flash("Your account is blocked.")
             else:
-                flask.session['login'] = c[0]['login']
-                flask.session['login_time'] = utils.now()
-                return flask.redirect(flask.url_for('view.index'))
+                flask.session["login"] = c[0]["login"]
+                flask.session["login_time"] = utils.now()
+                return flask.redirect(flask.url_for("view.index"))
 
         else:
             flask.flash("Wrong username or password")
 
-    return flask.render_template('login.html')
+    return flask.render_template("login.html")
 
-bp.route('/login', methods=['GET', 'POST'])(login)
+
+bp.route("/login", methods=["GET", "POST"])(login)
+
 
 def logout():
     flask.session.clear()
-    return flask.redirect(flask.url_for('auth.login'))
+    return flask.redirect(flask.url_for("auth.login"))
 
-bp.route('/logout')(logout)
+
+bp.route("/logout")(logout)
+
 
 def session():
-
-    if flask.request.blueprint == 'auth':
+    if flask.request.blueprint == "auth":
         return
 
-    if flask.request.endpoint == 'static':
+    if flask.request.endpoint == "static":
         return
 
-    login = flask.session.get('login')
+    login = flask.session.get("login")
 
     if login is None:
-        return flask.redirect(
-            flask.url_for('auth.login'))
+        return flask.redirect(flask.url_for("auth.login"))
 
-    latestValidSessionTime = utils.now() - 24*3600*flask.current_app.config['SESSION_LIFETIME']
-    lastLoginTime = flask.session.get('login_time')
+    latestValidSessionTime = utils.now() - 24 * 3600 * flask.current_app.config["SESSION_LIFETIME"]
+    lastLoginTime = flask.session.get("login_time")
 
     if lastLoginTime is None or lastLoginTime < latestValidSessionTime:
-        return flask.redirect(
-            flask.url_for('auth.login'))
+        return flask.redirect(flask.url_for("auth.login"))
 
     # check if user still exists and if it is not blocked
     c = Users.select(Users.account_type).where(Users.login == login)
 
-    if len(c) != 1 or c[0]['account_type'] >= ACCOUNT_TYPE_BLOCKED:
-        return flask.redirect(
-            flask.url_for('auth.login'))
+    if len(c) != 1 or c[0]["account_type"] >= ACCOUNT_TYPE_BLOCKED:
+        return flask.redirect(flask.url_for("auth.login"))
 
-    flask.g.isAdmin = c[0]['account_type'] == ACCOUNT_TYPE_ADMIN
+    flask.g.isAdmin = c[0]["account_type"] == ACCOUNT_TYPE_ADMIN
     flask.g.login = login
 
 

--- a/warp/auth_ldap.py
+++ b/warp/auth_ldap.py
@@ -1,32 +1,39 @@
-import flask
-from werkzeug.security import check_password_hash
-from warp.db import *
-import warp.auth
-from . import utils
-from ldap3 import Server, Connection, ALL, Tls
 import ssl
+import sys
+
+import flask
+import ldap3
+from ldap3 import ALL, Connection, Server, Tls
 from ldap3.core.exceptions import LDAPException
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.utils.dn import escape_rdn
-import ldap3
-import sys
+from werkzeug.security import check_password_hash
 
-bp = flask.Blueprint('auth', __name__)
+import .auth
+from .db import *
+
+from . import utils
+
+bp = flask.Blueprint("auth", __name__)
+
 
 def ldapConnect(login, password):
-
-    validateCert = flask.current_app.config.get('LDAP_VALIDATE_CERT',None)
-    tlsVersion = flask.current_app.config.get('LDAP_TLS_VERSION',None)
-    tlsCiphers = flask.current_app.config.get('LDAP_TLS_CIPHERS',None)
+    validateCert = flask.current_app.config.get("LDAP_VALIDATE_CERT", None)
+    tlsVersion = flask.current_app.config.get("LDAP_TLS_VERSION", None)
+    tlsCiphers = flask.current_app.config.get("LDAP_TLS_CIPHERS", None)
 
     tls_params = {}
     if validateCert is not None:
-        tls_params['validate'] = ssl.CERT_REQUIRED if validateCert else ssl.CERT_NONE
+        tls_params["validate"] = ssl.CERT_REQUIRED if validateCert else ssl.CERT_NONE
     if tlsVersion is not None:
-        if tlsVersion == "TLSv1": tls_params['version'] = ssl.PROTOCOL_TLSv1
-        elif tlsVersion == "TLSv1.1": tls_params['version'] = ssl.PROTOCOL_TLSv1_1
-        elif tlsVersion == "TLSv1.2": tls_params['version'] = ssl.PROTOCOL_TLSv1_2
-        else: print(f"Wrong TLS version specified {tlsVersion}",file=sys.stderr)
+        if tlsVersion == "TLSv1":
+            tls_params["version"] = ssl.PROTOCOL_TLSv1
+        elif tlsVersion == "TLSv1.1":
+            tls_params["version"] = ssl.PROTOCOL_TLSv1_1
+        elif tlsVersion == "TLSv1.2":
+            tls_params["version"] = ssl.PROTOCOL_TLSv1_2
+        else:
+            print(f"Wrong TLS version specified {tlsVersion}", file=sys.stderr)
     if tlsCiphers is not None:
         tls_params["ciphers"] = tlsCiphers
 
@@ -34,28 +41,33 @@ def ldapConnect(login, password):
     if tls_params:
         tls = ldap3.Tls(**tls_params)
 
-    url = flask.current_app.config.get('LDAP_SERVER_URL')
-    if not url.lower().startswith('ldap://') and not url.lower().startswith('ldaps://'):
-        print(f"LDAP_SERVER_URL must be either ldap:// or ldaps:// specified: {url}",file=sys.stderr)
+    url = flask.current_app.config.get("LDAP_SERVER_URL")
+    if not url.lower().startswith("ldap://") and not url.lower().startswith("ldaps://"):
+        print(
+            f"LDAP_SERVER_URL must be either ldap:// or ldaps:// specified: {url}", file=sys.stderr
+        )
         raise Exception("LDAP_SERVER_URL must be either ldap:// or ldaps://")
-    ldapServer = ldap3.Server(url,tls=tls,get_info=ALL)
+    ldapServer = ldap3.Server(url, tls=tls, get_info=ALL)
 
     userName = flask.current_app.config.get("LDAP_USER_TEMPLATE")
     userName = userName.format(login=escape_rdn(login))
 
-    ldapAuthType = flask.current_app.config.get('LDAP_AUTH_TYPE')
+    ldapAuthType = flask.current_app.config.get("LDAP_AUTH_TYPE")
     if ldapAuthType.upper() == "SIMPLE":
         ldapAuthType = ldap3.SIMPLE
     elif ldapAuthType.upper() == "NTLM":
         ldapAuthType = ldap3.NTLM
-        if '\\' not in userName:
-            print("For NTLM authentication LDAP_USER_TEMPLATE should contain Domain name.",file=sys.stderr)
+        if "\\" not in userName:
+            print(
+                "For NTLM authentication LDAP_USER_TEMPLATE should contain Domain name.",
+                file=sys.stderr,
+            )
     else:
-        print(f"Wrong LDAP_AUTH_TYPE specified {ldapAuthType}",file=sys.stderr)
+        print(f"Wrong LDAP_AUTH_TYPE specified {ldapAuthType}", file=sys.stderr)
         raise Exception("Wrong LDAP_AUTH_TYPE specified")
 
-    if '\\' in userName and not flask.current_app.config.get("LDAP_USER_SEARCH_BASE",None):
-        print("For AD authentication LDAP_USER_SEARCH_BASE should be configured.",file=sys.stderr)
+    if "\\" in userName and not flask.current_app.config.get("LDAP_USER_SEARCH_BASE", None):
+        print("For AD authentication LDAP_USER_SEARCH_BASE should be configured.", file=sys.stderr)
 
     ldapConnection = ldap3.Connection(
         ldapServer,
@@ -64,9 +76,10 @@ def ldapConnect(login, password):
         read_only=True,
         auto_bind=ldap3.AUTO_BIND_NONE,
         user=userName,
-        password=password)
+        password=password,
+    )
 
-    if flask.current_app.config.get('LDAP_STARTTLS') and url.lower().startswith('ldap://'):
+    if flask.current_app.config.get("LDAP_STARTTLS") and url.lower().startswith("ldap://"):
         ldapConnection.start_tls()
 
     if not ldapServer.ssl and not ldapConnection.tls_started:
@@ -77,40 +90,36 @@ def ldapConnect(login, password):
 
     return ldapConnection
 
-def ldapGetUserMetadata(login,ldapConnection):
 
-
-    userSearchBase = flask.current_app.config.get("LDAP_USER_SEARCH_BASE",None)
+def ldapGetUserMetadata(login, ldapConnection):
+    userSearchBase = flask.current_app.config.get("LDAP_USER_SEARCH_BASE", None)
     if not userSearchBase:
-        userSearchBase = flask.current_app.config.get("LDAP_USER_TEMPLATE","")
+        userSearchBase = flask.current_app.config.get("LDAP_USER_TEMPLATE", "")
     userSearchBase = userSearchBase.format(login=escape_rdn(login))
 
-    userSearchFilter = flask.current_app.config.get("LDAP_USER_SEARCH_FILTER_TEMPLATE","")
+    userSearchFilter = flask.current_app.config.get("LDAP_USER_SEARCH_FILTER_TEMPLATE", "")
     userSearchFilter = userSearchFilter.format(login=escape_rdn(login))
 
-    ldapNameAtt = flask.current_app.config.get('LDAP_USER_NAME_ATTRIBUTE')
-    ldapConnection.search(search_base=userSearchBase,
-                          search_filter=userSearchFilter,
-                          attributes=ldapNameAtt)
+    ldapNameAtt = flask.current_app.config.get("LDAP_USER_NAME_ATTRIBUTE")
+    ldapConnection.search(
+        search_base=userSearchBase, search_filter=userSearchFilter, attributes=ldapNameAtt
+    )
 
     if len(ldapConnection.entries) != 1:
-        raise Exception(f"LDAP: Wrong number of enties returned for the user: {len(ldapConnection.entries)}")
+        raise Exception(
+            f"LDAP: Wrong number of enties returned for the user: {len(ldapConnection.entries)}"
+        )
 
+    ret = {"userName": ldapConnection.entries[0][ldapNameAtt].value, "groups": []}
 
-    ret = {
-        "userName": ldapConnection.entries[0][ldapNameAtt].value,
-        "groups": []
-    }
-
-    searchBase = flask.current_app.config.get('LDAP_GROUP_SEARCH_BASE', None)
+    searchBase = flask.current_app.config.get("LDAP_GROUP_SEARCH_BASE", None)
     if searchBase is None:
         return ret
 
     loginAllowed = False
-    searchFilterTemplate = flask.current_app.config.get('LDAP_GROUP_SEARCH_FILTER_TEMPLATE')
-    ldapGroupMap = flask.current_app.config.get('LDAP_GROUP_MAP')
-    for ldapGroup,warpGroup in ldapGroupMap:
-
+    searchFilterTemplate = flask.current_app.config.get("LDAP_GROUP_SEARCH_FILTER_TEMPLATE")
+    ldapGroupMap = flask.current_app.config.get("LDAP_GROUP_MAP")
+    for ldapGroup, warpGroup in ldapGroupMap:
         if ldapGroup is None and warpGroup is None:
             loginAllowed = True
             continue
@@ -119,13 +128,18 @@ def ldapGetUserMetadata(login,ldapConnection):
             ret["groups"].append(warpGroup)
             continue
 
-        searchFilter = searchFilterTemplate.format(group=escape_filter_chars(ldapGroup),login=escape_filter_chars(login))
-        ldapConnection.search(search_base=searchBase,search_filter=searchFilter)
+        searchFilter = searchFilterTemplate.format(
+            group=escape_filter_chars(ldapGroup), login=escape_filter_chars(login)
+        )
+        ldapConnection.search(search_base=searchBase, search_filter=searchFilter)
 
         if len(ldapConnection.entries) == 0:
             continue
         elif len(ldapConnection.entries) > 1:
-            print("LDAP group search returned more than one entry. Probably LDAP_GROUP_SEARCH_FILTER is wrongly defined.",file=sys.stderr)
+            print(
+                "LDAP group search returned more than one entry. Probably LDAP_GROUP_SEARCH_FILTER is wrongly defined.",
+                file=sys.stderr,
+            )
 
         loginAllowed = True
         if warpGroup:
@@ -136,88 +150,87 @@ def ldapGetUserMetadata(login,ldapConnection):
 
     return ret
 
-def ldapApplyUserMetadata(login,userData):
 
+def ldapApplyUserMetadata(login, userData):
     with DB.atomic():
-
         c = Users.select(Users.name).where(Users.login == login).scalar()
         if c is None:
-            Users.insert({
-                Users.login: login,
-                Users.name: userData["userName"],
-                Users.account_type: ACCOUNT_TYPE_USER,
-                Users.password: '*'
-            }).execute()
+            Users.insert(
+                {
+                    Users.login: login,
+                    Users.name: userData["userName"],
+                    Users.account_type: ACCOUNT_TYPE_USER,
+                    Users.password: "*",
+                }
+            ).execute()
         elif c != userData["userName"]:
             Users.update({Users.name: userData["userName"]}).where(Users.login == login).execute()
 
-        existingGroups = Users.select( Users.login ) \
-            .where( Users.account_type == ACCOUNT_TYPE_GROUP ) \
-            .where( Users.login.in_(userData["groups"]) ) \
+        existingGroups = (
+            Users.select(Users.login)
+            .where(Users.account_type == ACCOUNT_TYPE_GROUP)
+            .where(Users.login.in_(userData["groups"]))
             .tuples()
+        )
         existingGroups = [i[0] for i in existingGroups]
 
         if len(existingGroups) != len(userData["groups"]):
-            print("LDAP WARNING: some of the groups defined in LDAP and mapped via LDAP_GROUP_MAP doesn't exist in Warp")
+            print(
+                "LDAP WARNING: some of the groups defined in LDAP and mapped via LDAP_GROUP_MAP doesn't exist in Warp"
+            )
 
-        insertData = [ {Groups.login: login, Groups.group: i} for i in existingGroups ]
-        #TODO: check if the materialized view is updated if no changes
+        insertData = [{Groups.login: login, Groups.group: i} for i in existingGroups]
+        # TODO: check if the materialized view is updated if no changes
         Groups.insert(insertData).on_conflict_ignore().execute()
 
-        strictMapping = flask.current_app.config.get('LDAP_GROUP_STRICT_MAPPING')
+        strictMapping = flask.current_app.config.get("LDAP_GROUP_STRICT_MAPPING")
         if strictMapping:
-            Groups.delete() \
-                .where( Groups.login == login ) \
-                .where( Groups.group.not_in(existingGroups) ) \
-                .execute()
-
+            Groups.delete().where(Groups.login == login).where(
+                Groups.group.not_in(existingGroups)
+            ).execute()
 
 
 def ldapLogin(login, password):
-
     if password is None or login is None:
         return flask.abort(400)
 
-    connection = ldapConnect(login,password)
+    connection = ldapConnect(login, password)
     if not connection:
         return False
 
-    userMetadata = ldapGetUserMetadata(login,connection)
+    userMetadata = ldapGetUserMetadata(login, connection)
     if not userMetadata:
         return False
 
-    ldapApplyUserMetadata(login,userMetadata)
+    ldapApplyUserMetadata(login, userMetadata)
 
-    flask.session['login'] = login
-    flask.session['login_time'] = utils.now()
+    flask.session["login"] = login
+    flask.session["login_time"] = utils.now()
 
     return True
 
 
-@bp.route('/login', methods=['GET', 'POST'])
+@bp.route("/login", methods=["GET", "POST"])
 def login():
-
     # clear session to force re-login
     flask.session.clear()
 
-    if flask.request.method == 'POST':
+    if flask.request.method == "POST":
+        u = flask.request.form.get("login")
+        p = flask.request.form.get("password")
 
-        u = flask.request.form.get('login')
-        p = flask.request.form.get('password')
-
-        LDAP_EXCLUDED_USERS = flask.current_app.config.get('LDAP_EXCLUDED_USERS', [])
+        LDAP_EXCLUDED_USERS = flask.current_app.config.get("LDAP_EXCLUDED_USERS", [])
 
         if u not in LDAP_EXCLUDED_USERS:
-
             if ldapLogin(u, p):
-                return flask.redirect(flask.url_for('view.index'))
+                return flask.redirect(flask.url_for("view.index"))
             flask.flash("Wrong username or password")
 
         else:
             return warp.auth.login()
 
-    return flask.render_template('login.html')
+    return flask.render_template("login.html")
 
 
-bp.route('/logout')(warp.auth.logout)
+bp.route("/logout")(warp.auth.logout)
 bp.before_app_request(warp.auth.session)

--- a/warp/auth_ldap.py
+++ b/warp/auth_ldap.py
@@ -3,16 +3,12 @@ import sys
 
 import flask
 import ldap3
-from ldap3 import ALL, Connection, Server, Tls
-from ldap3.core.exceptions import LDAPException
+from ldap3 import ALL
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.utils.dn import escape_rdn
-from werkzeug.security import check_password_hash
 
-import .auth
-from .db import *
-
-from . import utils
+from . import auth, utils
+from .db import ACCOUNT_TYPE_GROUP, ACCOUNT_TYPE_USER, DB, Groups, Users
 
 bp = flask.Blueprint("auth", __name__)
 
@@ -227,10 +223,10 @@ def login():
             flask.flash("Wrong username or password")
 
         else:
-            return warp.auth.login()
+            return auth.login()
 
     return flask.render_template("login.html")
 
 
-bp.route("/logout")(warp.auth.logout)
-bp.before_app_request(warp.auth.session)
+bp.route("/logout")(auth.logout)
+bp.before_app_request(auth.session)

--- a/warp/auth_mellon.py
+++ b/warp/auth_mellon.py
@@ -1,69 +1,65 @@
 import flask
-from .db import *
+
 from warp.auth import session
+
 from . import utils
+from .db import *
 
-bp = flask.Blueprint('auth', __name__)
+bp = flask.Blueprint("auth", __name__)
 
-@bp.route('/login')
+
+@bp.route("/login")
 def login():
-
     # force SAML request
-    if flask.session.get('login'):
-
+    if flask.session.get("login"):
         flask.session.clear()
 
-        mellonEndpoint = flask.current_app.config['MELLON_ENDPOINT']
+        mellonEndpoint = flask.current_app.config["MELLON_ENDPOINT"]
         endpoint = f"{mellonEndpoint}/login?ReturnTo={flask.url_for('auth.login')}"
 
         return flask.redirect(endpoint)
 
-    login = flask.request.environ.get('MELLON_uid')
-    userName = flask.request.environ.get('MELLON_cn')
-    #login = flask.request.headers.get('X-MELLON_uid')
-    #userName = flask.request.headers.get('X-MELLON_cn')
-    if (login is None or userName is None):
+    login = flask.request.environ.get("MELLON_uid")
+    userName = flask.request.environ.get("MELLON_cn")
+    # login = flask.request.headers.get('X-MELLON_uid')
+    # userName = flask.request.headers.get('X-MELLON_cn')
+    if login is None or userName is None:
         return flask.abort(400)
 
-    userName = bytes(userName,'ISO-8859-1').decode('utf-8')
+    userName = bytes(userName, "ISO-8859-1").decode("utf-8")
 
     c = Users.select(Users.name).where(Users.login == login).scalar()
 
     if c is None:
-
         with DB.atomic():
+            Users.insert(
+                {
+                    Users.login: login,
+                    Users.name: userName,
+                    Users.account_type: ACCOUNT_TYPE_USER,
+                    Users.password: "*",
+                }
+            ).execute()
 
-            Users.insert({
-                Users.login: login,
-                Users.name: userName,
-                Users.account_type: ACCOUNT_TYPE_USER,
-                Users.password: '*'
-            }).execute()
-
-            defaultGroup = flask.current_app.config.get('MELLON_DEFAULT_GROUP')
+            defaultGroup = flask.current_app.config.get("MELLON_DEFAULT_GROUP")
             if defaultGroup is not None:
-                Groups.insert({
-                    Groups.group: defaultGroup,
-                    Groups.login: login
-                }).execute()
+                Groups.insert({Groups.group: defaultGroup, Groups.login: login}).execute()
 
     elif c != userName:
-
         with DB.atomic():
             Users.update({Users.name: userName}).where(Users.login == login).execute()
 
+    flask.session["login"] = login
+    flask.session["login_time"] = utils.now()
 
-    flask.session['login'] = login
-    flask.session['login_time'] = utils.now()
+    return flask.redirect(flask.url_for("view.index"))
 
-    return flask.redirect(flask.url_for('view.index'))
 
-@bp.route('/logout')
+@bp.route("/logout")
 def logout():
-
     flask.session.clear()
 
-    mellonEndpoint = flask.current_app.config['MELLON_ENDPOINT']
+    mellonEndpoint = flask.current_app.config["MELLON_ENDPOINT"]
     endpoint = f"{mellonEndpoint}/logout?ReturnTo={flask.url_for('auth.login')}"
 
     return flask.redirect(endpoint)

--- a/warp/auth_mellon.py
+++ b/warp/auth_mellon.py
@@ -1,9 +1,8 @@
 import flask
 
-from warp.auth import session
-
 from . import utils
-from .db import *
+from .auth import session
+from .db import ACCOUNT_TYPE_USER, DB, Groups, Users
 
 bp = flask.Blueprint("auth", __name__)
 

--- a/warp/blob_storage.py
+++ b/warp/blob_storage.py
@@ -3,7 +3,7 @@ import io
 import flask
 from flask.wrappers import Response
 
-from warp.db import *
+from .db import DB, Blobs
 
 
 def deleteBlob(blobId=None, blobIdQuery=None):

--- a/warp/blob_storage.py
+++ b/warp/blob_storage.py
@@ -2,65 +2,55 @@ import io
 
 import flask
 from flask.wrappers import Response
+
 from warp.db import *
 
-def deleteBlob(blobId = None, blobIdQuery = None):
 
+def deleteBlob(blobId=None, blobIdQuery=None):
     if blobId is not None:
-        query = Blobs.delete() \
-                     .where(Blobs.id == blobId)
+        query = Blobs.delete().where(Blobs.id == blobId)
     elif blobIdQuery is not None:
-        query = Blobs.delete() \
-                     .where(Blobs.id.in_(blobIdQuery))
+        query = Blobs.delete().where(Blobs.id.in_(blobIdQuery))
     else:
         return 0
 
     with DB.atomic():
-
         rowCount = query.execute()
 
     return rowCount
 
 
-def addOrUpdateBlob(mimeType, data, blobId = None):
-
+def addOrUpdateBlob(mimeType, data, blobId=None):
     with DB.atomic():
-
         if blobId is not None:
-
-            rowCount = Blobs.update({
-                            Blobs.mimetype: mimeType,
-                            Blobs.data: data,
-                            Blobs.etag: Blobs.etag + 1
-                        }).where(Blobs.id == blobId).execute()
+            rowCount = (
+                Blobs.update(
+                    {Blobs.mimetype: mimeType, Blobs.data: data, Blobs.etag: Blobs.etag + 1}
+                )
+                .where(Blobs.id == blobId)
+                .execute()
+            )
 
             if rowCount != 1:
                 return None
 
         else:
+            insertCursor = (
+                Blobs.insert({Blobs.mimetype: mimeType, Blobs.data: data, Blobs.etag: 1})
+                .returning(Blobs.id)
+                .execute()
+            )
 
-            insertCursor = Blobs.insert({
-                                Blobs.mimetype: mimeType,
-                                Blobs.data: data,
-                                Blobs.etag: 1
-                                }) \
-                            .returning(Blobs.id) \
-                            .execute()
-
-            blobId = insertCursor[0]['id']
+            blobId = insertCursor[0]["id"]
 
     return blobId
 
 
-
-def createBlobResponse(blobId = None, blobIdQuery = None):
-
+def createBlobResponse(blobId=None, blobIdQuery=None):
     if blobId is not None:
-        query = Blobs.select() \
-                     .where(Blobs.id == blobId)
+        query = Blobs.select().where(Blobs.id == blobId)
     elif blobIdQuery is not None:
-        query = Blobs.select() \
-                     .where(Blobs.id.in_(blobIdQuery))
+        query = Blobs.select().where(Blobs.id.in_(blobIdQuery))
     else:
         flask.abort(400)
 
@@ -76,19 +66,14 @@ def createBlobResponse(blobId = None, blobIdQuery = None):
     if r304.status_code != 200:
         return r304
 
-    row = query.columns(Blobs.data, Blobs.mimetype).scalar(as_tuple = True)
+    row = query.columns(Blobs.data, Blobs.mimetype).scalar(as_tuple=True)
 
     if row is None:
         flask.abort(404)
 
-    resp = flask.send_file(
-        io.BytesIO(row[0]),
-        mimetype=row[1],
-        etag=blobEtag)
+    resp = flask.send_file(io.BytesIO(row[0]), mimetype=row[1], etag=blobEtag)
 
     resp.cache_control.no_cache = True
     resp.cache_control.private = True
 
     return resp
-
-

--- a/warp/config.py
+++ b/warp/config.py
@@ -1,11 +1,11 @@
 import json
 import os
 
-__all__ = ['initConfig']
+__all__ = ["initConfig"]
+
 
 class DefaultSettings(object):
-
-    LANGUAGE_FILE="i18n/en.js"
+    LANGUAGE_FILE = "i18n/en.js"
 
     # after how many days force user to re-login (note that it is not a session timeout)
     SESSION_LIFETIME = 1
@@ -35,7 +35,7 @@ class DefaultSettings(object):
     LDAP_USER_NAME_ATTRIBUTE = "cn"
     LDAP_USER_SEARCH_FILTER_TEMPLATE = "(objectClass=person)"
     LDAP_GROUP_SEARCH_FILTER_TEMPLATE = "(&(memberUid={login})(cn={group}))"
-    LDAP_GROUP_MAP = [ [None,None] ]
+    LDAP_GROUP_MAP = [[None, None]]
     LDAP_GROUP_STRICT_MAPPING = False
     LDAP_EXCLUDED_USERS = []
 
@@ -59,61 +59,56 @@ class DefaultSettings(object):
     # MELLON_ENDPOINT
     # MELLON_DEFAULT_GROUP
 
-class DevelopmentSettings(DefaultSettings):
 
+class DevelopmentSettings(DefaultSettings):
     DATABASE = "postgresql://postgres:postgres_password@127.0.0.1:5432/postgres"
 
-    #DATABASE = "sqlite:///warp/db.sqlite"
-    #DATABASE_ARGS = {"pragmas": {"foreign_keys": "ON"}}
+    # DATABASE = "sqlite:///warp/db.sqlite"
+    # DATABASE_ARGS = {"pragmas": {"foreign_keys": "ON"}}
 
-    DATABASE_INIT_SCRIPT = [
-        "sql/clean_db.sql",
-        "sql/schema.sql",
-        "sql/sample_data.sql"
-    ]
+    DATABASE_INIT_SCRIPT = ["sql/clean_db.sql", "sql/schema.sql", "sql/sample_data.sql"]
 
-    SECRET_KEY = b'change_me'
+    SECRET_KEY = b"change_me"
 
 
 class ProductionSettings(DefaultSettings):
-
     # use mellon (Apache SAML module) for authentication
-    #AUTH_MELLON = False
-    #MELLON_ENDPOINT = "/sp"
-    #MELLON_DEFAULT_GROUP = "everybody"
+    # AUTH_MELLON = False
+    # MELLON_ENDPOINT = "/sp"
+    # MELLON_DEFAULT_GROUP = "everybody"
 
     # this is intentionally empty, as in production
     # DATABASE and SECRET_KEY should be passed via ENV
     # as WARP_SECRET_KEY and WARP_DATABASE
     pass
 
-def readEnvironmentSettings(app):
 
-    PREFIX="WARP_"
+def readEnvironmentSettings(app):
+    PREFIX = "WARP_"
 
     res = {}
-    for key,val in os.environ.items():
+    for key, val in os.environ.items():
         if key.startswith(PREFIX):
             try:
-                val = json.loads(val.lower())       # try to parse any valid json type
+                val = json.loads(val.lower())  # try to parse any valid json type
             except json.decoder.JSONDecodeError:
-                pass                                # fallback to string (no change)
+                pass  # fallback to string (no change)
             res[key.removeprefix(PREFIX)] = val
 
     app.config.update(res)
 
 
-
 def initConfig(app):
-
-    if app.env != 'production':
+    if app.env != "production":
         app.config.from_object(DevelopmentSettings)
     else:
         app.config.from_object(ProductionSettings)
 
     readEnvironmentSettings(app)
 
-    if app.config.get('SECRET_KEY',None) is None:
-        raise Exception('SECRET_KEY must be defined or passed via WARP_SECRET_KEY environment variable')
-    if app.config.get('DATABASE',None) is None:
-        raise Exception('DATABASE must be defined or passed via WARP_DATABASE environment variable')
+    if app.config.get("SECRET_KEY", None) is None:
+        raise Exception(
+            "SECRET_KEY must be defined or passed via WARP_SECRET_KEY environment variable"
+        )
+    if app.config.get("DATABASE", None) is None:
+        raise Exception("DATABASE must be defined or passed via WARP_DATABASE environment variable")

--- a/warp/db.py
+++ b/warp/db.py
@@ -1,28 +1,28 @@
+import sys
 from functools import partial
 from time import sleep
-import sys
 
-from peewee import Table, SQL, fn, IntegrityError, DatabaseError, OperationalError
-import playhouse.db_url
 import click
-from flask.cli import with_appcontext
+import playhouse.db_url
 from flask import current_app
+from flask.cli import with_appcontext
+from peewee import SQL, DatabaseError, IntegrityError, OperationalError, Table, fn
 
 DB = None
 
-Blobs = Table('blobs',('id','mimetype','data','etag'),primary_key='id')
-Users = Table('users',('login','password','name','account_type'))
-Groups = Table('groups',('group','login'))
-Seat = Table('seat',('id','zid','name','x','y','enabled'))
-Zone = Table('zone',('id','zone_group','name','iid'))
-ZoneAssign = Table('zone_assign',('zid','login','zone_role'))
-Book = Table('book',('id','login','sid','fromts','tots'))
-SeatAssign = Table('seat_assign',('sid','login'))
+Blobs = Table("blobs", ("id", "mimetype", "data", "etag"), primary_key="id")
+Users = Table("users", ("login", "password", "name", "account_type"))
+Groups = Table("groups", ("group", "login"))
+Seat = Table("seat", ("id", "zid", "name", "x", "y", "enabled"))
+Zone = Table("zone", ("id", "zone_group", "name", "iid"))
+ZoneAssign = Table("zone_assign", ("zid", "login", "zone_role"))
+Book = Table("book", ("id", "login", "sid", "fromts", "tots"))
+SeatAssign = Table("seat_assign", ("sid", "login"))
 
-UserToZoneRoles = Table('user_to_zone_roles',('login','zid','zone_role'))
+UserToZoneRoles = Table("user_to_zone_roles", ("login", "zid", "zone_role"))
 
-COUNT_STAR = fn.COUNT(SQL('*'))
-SQL_ONE = SQL('1')
+COUNT_STAR = fn.COUNT(SQL("*"))
+SQL_ONE = SQL("1")
 
 # the highest role must be the lowest value
 ACCOUNT_TYPE_ADMIN = 10
@@ -35,25 +35,45 @@ ZONE_ROLE_ADMIN = 10
 ZONE_ROLE_USER = 20
 ZONE_ROLE_VIEWER = 30
 
-__all__ = ["DB", "Blobs", "Users", "Groups","Seat", "Zone", "ZoneAssign", "Book","SeatAssign","UserToZoneRoles",
-           "IntegrityError", "COUNT_STAR", "SQL_ONE",
-           'ACCOUNT_TYPE_ADMIN','ACCOUNT_TYPE_USER','ACCOUNT_TYPE_BLOCKED','ACCOUNT_TYPE_GROUP',
-           'ZONE_ROLE_ADMIN', 'ZONE_ROLE_USER', 'ZONE_ROLE_VIEWER']
+__all__ = [
+    "DB",
+    "Blobs",
+    "Users",
+    "Groups",
+    "Seat",
+    "Zone",
+    "ZoneAssign",
+    "Book",
+    "SeatAssign",
+    "UserToZoneRoles",
+    "IntegrityError",
+    "COUNT_STAR",
+    "SQL_ONE",
+    "ACCOUNT_TYPE_ADMIN",
+    "ACCOUNT_TYPE_USER",
+    "ACCOUNT_TYPE_BLOCKED",
+    "ACCOUNT_TYPE_GROUP",
+    "ZONE_ROLE_ADMIN",
+    "ZONE_ROLE_USER",
+    "ZONE_ROLE_VIEWER",
+]
 
-_INITIALIZED_TABLE = 'db_initialized'
+_INITIALIZED_TABLE = "db_initialized"
+
 
 def _connect():
     DB.connect()
 
+
 def _disconnect(ctx):
     DB.close()
 
-def init(app):
 
+def init(app):
     global DB
 
-    connStr = app.config['DATABASE']
-    connArgs = app.config['DATABASE_ARGS'] if 'DATABASE_ARGS' in app.config else {}
+    connStr = app.config["DATABASE"]
+    connArgs = app.config["DATABASE_ARGS"] if "DATABASE_ARGS" in app.config else {}
 
     DB = playhouse.db_url.connect(connStr, autoconnect=False, thread_safe=True, **connArgs)
 
@@ -70,70 +90,70 @@ def init(app):
     app.before_request(_connect)
     app.teardown_request(_disconnect)
 
-    if 'DATABASE_INIT_SCRIPT' in app.config:
-
-        commandParams = {"help": "Create and initialize database.", 'callback': with_appcontext(partial(initDB,True)) }
-        cmd = click.Command('init-db', **commandParams)
+    if "DATABASE_INIT_SCRIPT" in app.config:
+        commandParams = {
+            "help": "Create and initialize database.",
+            "callback": with_appcontext(partial(initDB, True)),
+        }
+        cmd = click.Command("init-db", **commandParams)
         app.cli.add_command(cmd)
 
-    if '--help' not in sys.argv[1:] and 'init-db' not in sys.argv[1:]:
+    if "--help" not in sys.argv[1:] and "init-db" not in sys.argv[1:]:
         with app.app_context():
             initDB()
 
-def initDB(force = False):
 
-    initScripts = current_app.config.get('DATABASE_INIT_SCRIPT')
+def initDB(force=False):
+    initScripts = current_app.config.get("DATABASE_INIT_SCRIPT")
 
     if not initScripts:
         print("DATABASE_INIT_SCRIPT not defined ")
         return
 
-    if isinstance(initScripts,str):
-        initScripts = [ initScripts ]
+    if isinstance(initScripts, str):
+        initScripts = [initScripts]
 
-    retries = current_app.config['DATABASE_INIT_RETRIES']
-    retDelay = current_app.config['DATABASE_INIT_RETRIES_DELAY']
+    retries = current_app.config["DATABASE_INIT_RETRIES"]
+    retDelay = current_app.config["DATABASE_INIT_RETRIES_DELAY"]
 
     if retries < 1:
         retries = 1
 
     while True:
-
         try:
-
             with DB:
-
                 if not force:
-
                     try:
                         DB.execute_sql(f"CREATE TABLE {_INITIALIZED_TABLE}();")
                     except DatabaseError:
                         # database already initialized
                         return
 
-                print(f'Initializing DB force={force}')
+                print(f"Initializing DB force={force}")
 
                 for file in initScripts:
-
-                    print(f'Executing SQL: {file}')
+                    print(f"Executing SQL: {file}")
 
                     with current_app.open_resource(file) as f:
-                        sql = f.read().decode('utf8')
+                        sql = f.read().decode("utf8")
                         DB.execute(SQL(sql))
 
                 # in case it is cleaned up in the above scripts (or force == True)
                 DB.execute_sql(f"CREATE TABLE IF NOT EXISTS {_INITIALIZED_TABLE}();")
 
-            print('The database initialized.')
+            print("The database initialized.")
             break
 
         except OperationalError:
-
             retries -= 1
             if retries == 0:
                 print(f"ERROR: Cannot connect to the database.", file=sys.stderr, flush=True)
                 raise
 
-            print(f"Database connection error, waiting {retDelay} second(s).", file=sys.stderr, flush=True)
+            print(
+                f"Database connection error, waiting {retDelay} second(s).",
+                file=sys.stderr,
+                flush=True,
+            )
             sleep(retDelay)
-            print(f'Retrying ({retries}).', file=sys.stderr, flush=True)
+            print(f"Retrying ({retries}).", file=sys.stderr, flush=True)

--- a/warp/utils.py
+++ b/warp/utils.py
@@ -1,38 +1,42 @@
-import flask
-
-from calendar import timegm
-from time import localtime,strftime,gmtime
-from jsonschema import validate, ValidationError
 import functools
+from calendar import timegm
+from time import gmtime, localtime, strftime
+
+import flask
+from jsonschema import ValidationError, validate
+
 
 def now():
-    """ Returns number of seconds since midnight 1970-1-1 in the current timezone until now"""
+    """Returns number of seconds since midnight 1970-1-1 in the current timezone until now"""
     """ It is timezone unaware version of unix timestamp """
     return timegm(localtime())
 
+
 def today():
-    """ Returns number of seconds since midnight 1970-1-1 in the current timezone until today's midnight"""
+    """Returns number of seconds since midnight 1970-1-1 in the current timezone until today's midnight"""
     """ It is utils.now() with stipped hour """
 
     n = now()
-    return n - n % (24*3600)
+    return n - n % (24 * 3600)
+
 
 # format { "fromTS": 123, "toTS": 123 }
-def getTimeRange(extended = False):
-    """ Returns a dict with fromTS and toTS """
+def getTimeRange(extended=False):
+    """Returns a dict with fromTS and toTS"""
     """ today's midnight, today's midnight + WEEKS_IN_ADVANCE """
 
     fromTS = today()
 
-    weeksInAdvance = flask.current_app.config['WEEKS_IN_ADVANCE']
+    weeksInAdvance = flask.current_app.config["WEEKS_IN_ADVANCE"]
     if extended:
         weeksInAdvance += 2
 
     t = gmtime(fromTS)
-    toTS = (7 - t.tm_wday) + weeksInAdvance*7
-    toTS = 24*3600*toTS + fromTS
+    toTS = (7 - t.tm_wday) + weeksInAdvance * 7
+    toTS = 24 * 3600 * toTS + fromTS
 
-    return { "fromTS": fromTS, "toTS": toTS}
+    return {"fromTS": fromTS, "toTS": toTS}
+
 
 # format
 # [
@@ -43,7 +47,7 @@ def getTimeRange(extended = False):
 #   },...
 # ]
 def getNextWeek():
-    """ Returns a structure containing timestamp and date string for days """
+    """Returns a structure containing timestamp and date string for days"""
     """ from today until the end of next week"""
 
     ts = today()
@@ -51,62 +55,63 @@ def getNextWeek():
     res = []
     noOfSundays = 0
 
-    weeksInAdvance = flask.current_app.config['WEEKS_IN_ADVANCE']
+    weeksInAdvance = flask.current_app.config["WEEKS_IN_ADVANCE"]
 
     while noOfSundays <= weeksInAdvance:
-
         t = gmtime(ts)
-        res.append( {
-            "timestamp": ts,
-            "date": strftime("%Y-%m-%d",t),
-            "weekdayN": strftime("%w",t),
-            "isWeekend": t.tm_wday>=5
-        })
+        res.append(
+            {
+                "timestamp": ts,
+                "date": strftime("%Y-%m-%d", t),
+                "weekdayN": strftime("%w", t),
+                "isWeekend": t.tm_wday >= 5,
+            }
+        )
 
-        ts = ts + 24*3600
+        ts = ts + 24 * 3600
 
         if t.tm_wday == 6:
             noOfSundays = noOfSundays + 1
 
     return res
 
-def formatTimestamp(ts):
 
+def formatTimestamp(ts):
     t = gmtime(ts)
-    return strftime("%Y-%m-%d %H:%M",t)
+    return strftime("%Y-%m-%d %H:%M", t)
+
 
 def formatTimespan(fromTS, toTS):
     fromT = gmtime(fromTS)
     toT = gmtime(toTS)
 
-    if (fromT[0],fromT[1],fromT[2]) ==  (toT[0],toT[1],toT[2]):
-        return strftime("%a, %Y-%m-%d %H:%M",fromT)+strftime("-%H:%M",toT)
+    if (fromT[0], fromT[1], fromT[2]) == (toT[0], toT[1], toT[2]):
+        return strftime("%a, %Y-%m-%d %H:%M", fromT) + strftime("-%H:%M", toT)
     else:
-        return strftime("%Y-%m-%d %H:%M",fromT)+strftime(" - %Y-%m-%d %H:%M",toT)
+        return strftime("%Y-%m-%d %H:%M", fromT) + strftime(" - %Y-%m-%d %H:%M", toT)
 
-def validateJSONInput(jsonSchema, isAdmin = False):
 
+def validateJSONInput(jsonSchema, isAdmin=False):
     def inner(func):
-
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-                if not flask.request.is_json:
-                    return {"msg": "Non-JSON request", "code": 10 }, 404
+            if not flask.request.is_json:
+                return {"msg": "Non-JSON request", "code": 10}, 404
 
-                if isAdmin and not flask.g.isAdmin:
-                    return {"msg": "Forbidden", "code": 11 }, 403
+            if isAdmin and not flask.g.isAdmin:
+                return {"msg": "Forbidden", "code": 11}, 403
 
-                from werkzeug.exceptions import BadRequest
+            from werkzeug.exceptions import BadRequest
 
-                try:
-                    jsonData = flask.request.get_json()
-                    validate(jsonData,jsonSchema)
-                except BadRequest:
-                    return {"msg": "Error in paring JSON", "code": 12 }, 404
-                except ValidationError as err:
-                    return {"msg": "Data error", "code": 13 }, 400
+            try:
+                jsonData = flask.request.get_json()
+                validate(jsonData, jsonSchema)
+            except BadRequest:
+                return {"msg": "Error in paring JSON", "code": 12}, 404
+            except ValidationError as err:
+                return {"msg": "Data error", "code": 13}, 400
 
-                return func(*args, **kwargs)
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/warp/utils_tabulator.py
+++ b/warp/utils_tabulator.py
@@ -1,23 +1,21 @@
 import operator
+
 import peewee
 
-__all__ = ['addToTabulatorSchema','applyTabulatorToQuery','tabulatorSchema']
+__all__ = ["addToTabulatorSchema", "applyTabulatorToQuery", "tabulatorSchema"]
 
 tabulatorSchema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "page" : {"type" : "integer"},
-        "size" : {"type" : "integer"},
+        "page": {"type": "integer"},
+        "size": {"type": "integer"},
         "sort": {
             "type": "array",
             "items": {
                 "type": "object",
-                "properties": {
-                    "field" : {"type" : "string"},
-                    "dir" : {"enum" : ["asc", "desc"] }
-                },
-                "required": [ "field", "dir"],
+                "properties": {"field": {"type": "string"}, "dir": {"enum": ["asc", "desc"]}},
+                "required": ["field", "dir"],
             },
         },
         "filter": {
@@ -25,56 +23,44 @@ tabulatorSchema = {
             "items": {
                 "type": "object",
                 "properties": {
-                    "field" : {"type" : "string"},
-                    "type" : {"enum" : ["starts", "=", "!=", "<", "<=", ">", ">="] }
+                    "field": {"type": "string"},
+                    "type": {"enum": ["starts", "=", "!=", "<", "<=", ">", ">="]},
                 },
-                "required": [ "field", "type", "value"],
+                "required": ["field", "type", "value"],
                 "allOf": [
                     {
-                        "if": {
-                            "properties": { "type" : {"enum" : ["starts"] } }
-                        },
-                        "then": {
-                            "properties": { "value" : {"type" : "string" } }
-                        }
+                        "if": {"properties": {"type": {"enum": ["starts"]}}},
+                        "then": {"properties": {"value": {"type": "string"}}},
                     },
                     {
-                        "if": {
-                            "properties": { "type" : {"enum" : ["=", "!=", "<", "<=", ">", ">="] } }
-                        },
-                        "then": {
-                            "properties": { "value" : {"type" : ["string","integer","array"] } }
-                        }
+                        "if": {"properties": {"type": {"enum": ["=", "!=", "<", "<=", ">", ">="]}}},
+                        "then": {"properties": {"value": {"type": ["string", "integer", "array"]}}},
                     },
                     {
-                        "if": {
-                            "properties": { "value" : {"type" : "array"} }
-                        },
+                        "if": {"properties": {"value": {"type": "array"}}},
                         "then": {
                             "properties": {
-                                "value" : {
-                                    "items": {"type": ["integer","null"]},
+                                "value": {
+                                    "items": {"type": ["integer", "null"]},
                                 },
                             }
-                        }
-                    }
-                ]
+                        },
+                    },
+                ],
             },
         },
     },
-    "dependentRequired": {
-        "page": ["size"]
-    }
+    "dependentRequired": {"page": ["size"]},
 }
+
 
 # it merges jsonSchema with default tabulator schema
 # but it is very dumb (dicts are added to dicts, lists to lists)
 # so if you are not carefull the output schema may basically be wrong
 def addToTabulatorSchema(jsonSchema):
-
     import collections.abc
-    from functools import reduce
     import copy
+    from functools import reduce
 
     def mergeSchemas(a, b):
         for k in b:
@@ -82,10 +68,13 @@ def addToTabulatorSchema(jsonSchema):
                 a[k] = b[k]
             else:
                 if isinstance(a[k], dict) and isinstance(b[k], dict):
-                    mergeSchemas(a[k],b[k])
+                    mergeSchemas(a[k], b[k])
                 elif isinstance(a[k], list) and isinstance(b[k], list):
-
-                    hashable = reduce(lambda a,b: a and isinstance(b,collections.abc.Hashable), a[k]+b[k], True)
+                    hashable = reduce(
+                        lambda a, b: a and isinstance(b, collections.abc.Hashable),
+                        a[k] + b[k],
+                        True,
+                    )
                     if hashable:
                         tmpSet = set(a[k])
                         tmpSet.update(b[k])
@@ -95,31 +84,31 @@ def addToTabulatorSchema(jsonSchema):
                 elif a[k] == b[k]:
                     pass
                 else:
-                    raise Exception('Different types in merged schemas, key='+k)
+                    raise Exception("Different types in merged schemas, key=" + k)
 
     schema = copy.deepcopy(tabulatorSchema)
-    mergeSchemas(schema,jsonSchema)
+    mergeSchemas(schema, jsonSchema)
 
     return schema
+
 
 # returns (query,lastPage)
 #
 # functionOperator is used for 'function' comparison
 # it is def fo(field,value) -> peewee.Expression
-def applyTabulatorToQuery(query,requestJSON,columnsMap = None,functionOperator = None):
-
+def applyTabulatorToQuery(query, requestJSON, columnsMap=None, functionOperator=None):
     def getColName(c):
-        if isinstance(c,peewee.Alias):
+        if isinstance(c, peewee.Alias):
             return c._alias
-        if isinstance(c,peewee.Column):
+        if isinstance(c, peewee.Column):
             return c.name
-        raise Exception('Wrong type, please provide columnMap')
+        raise Exception("Wrong type, please provide columnMap")
 
     if columnsMap is None:
         # _returning is private, but it seems there is no public method to read it
-        columnsMap = { getColName(i): i for i in query._returning }
-    elif isinstance(columnsMap,list):
-        columnsMap = { getColName(i): i for i in columnsMap }
+        columnsMap = {getColName(i): i for i in query._returning}
+    elif isinstance(columnsMap, list):
+        columnsMap = {getColName(i): i for i in columnsMap}
 
     operatorsMap = {
         "=": operator.__eq__,
@@ -128,45 +117,46 @@ def applyTabulatorToQuery(query,requestJSON,columnsMap = None,functionOperator =
         "<=": operator.__le__,
         ">": operator.__gt__,
         ">=": operator.__ge__,
-        'starts': lambda field,value: field.startswith(value)
+        "starts": lambda field, value: field.startswith(value),
     }
 
     if functionOperator is not None:
-        operatorsMap['function'] = functionOperator
+        operatorsMap["function"] = functionOperator
 
     if "filter" in requestJSON:
-        for i in requestJSON['filter']:
+        for i in requestJSON["filter"]:
             if i["field"] in columnsMap:
                 field = columnsMap[i["field"]]
-                if i['type'] in operatorsMap:
-
+                if i["type"] in operatorsMap:
                     value = i["value"]
-                    op = operatorsMap[i['type']]
+                    op = operatorsMap[i["type"]]
 
                     # for some reason sometimes (when dropdown is shown) tabulator sends it as array
-                    if isinstance(value,list):
+                    if isinstance(value, list):
                         value = value[0]
 
-                    query = query.where( op(field,i["value"]) )
+                    query = query.where(op(field, i["value"]))
 
     lastPage = None
     if "size" in requestJSON:
-
-        limit = requestJSON['size']
+        limit = requestJSON["size"]
 
         if "page" in requestJSON:
-
             count = query.count()
-            lastPage = -(-count // limit)   # round up
+            lastPage = -(-count // limit)  # round up
 
-            offset = (requestJSON['page']-1)*requestJSON['size']
+            offset = (requestJSON["page"] - 1) * requestJSON["size"]
             query = query.offset(offset)
 
         query = query.limit(limit)
 
     if "sort" in requestJSON:
-        for i in requestJSON['sort']:
+        for i in requestJSON["sort"]:
             if i["field"] in columnsMap:
-                query = query.order_by_extend( columnsMap[i["field"]].asc() if i["dir"] == "asc" else columnsMap[i["field"]].desc() )
+                query = query.order_by_extend(
+                    columnsMap[i["field"]].asc()
+                    if i["dir"] == "asc"
+                    else columnsMap[i["field"]].desc()
+                )
 
-    return (query,lastPage)
+    return (query, lastPage)

--- a/warp/view.py
+++ b/warp/view.py
@@ -1,192 +1,196 @@
 import flask
 
 from warp.db import *
-from . import utils
-from . import blob_storage
 
-bp = flask.Blueprint('view', __name__)
+from . import blob_storage, utils
+
+bp = flask.Blueprint("view", __name__)
+
 
 @bp.context_processor
 def headerDataInit():
-
     headerDataL = []
 
-    zoneCursor = Zone.select(Zone.id, Zone.name) \
-                     .join(UserToZoneRoles, on=(Zone.id == UserToZoneRoles.zid)) \
-                     .where(UserToZoneRoles.login == flask.g.login) \
-                     .order_by(Zone.name)
+    zoneCursor = (
+        Zone.select(Zone.id, Zone.name)
+        .join(UserToZoneRoles, on=(Zone.id == UserToZoneRoles.zid))
+        .where(UserToZoneRoles.login == flask.g.login)
+        .order_by(Zone.name)
+    )
 
     for z in zoneCursor:
         headerDataL.append(
-            {"text": z['name'], "endpoint": "view.zone", "view_args": {"zid":str(z['id'])} })
+            {"text": z["name"], "endpoint": "view.zone", "view_args": {"zid": str(z["id"])}}
+        )
 
     if headerDataL:
-        headerDataL.insert(0,{"text": "Bookings", "endpoint": "view.bookings", "view_args": {"report":""} })
+        headerDataL.insert(
+            0, {"text": "Bookings", "endpoint": "view.bookings", "view_args": {"report": ""}}
+        )
 
     headerDataR = [
-        {"text": "Report", "endpoint": "view.bookings", "view_args": {"report": "report"} },
-        {"text": "Users", "endpoint": "view.users", "view_args": {} },
-        {"text": "Groups", "endpoint": "view.groups", "view_args": {} },
-        {"text": "Zones", "endpoint": "view.zones", "view_args": {} }
+        {"text": "Report", "endpoint": "view.bookings", "view_args": {"report": "report"}},
+        {"text": "Users", "endpoint": "view.users", "view_args": {}},
+        {"text": "Groups", "endpoint": "view.groups", "view_args": {}},
+        {"text": "Zones", "endpoint": "view.zones", "view_args": {}},
     ]
 
-    #generate urls and selected
-    for hdata in [headerDataL,headerDataR]:
-
+    # generate urls and selected
+    for hdata in [headerDataL, headerDataR]:
         for h in hdata:
+            h["url"] = flask.url_for(h["endpoint"], **h["view_args"])
+            a = flask.request.endpoint == h["endpoint"]
+            b = flask.request.view_args == h["view_args"]
+            h["active"] = (
+                flask.request.endpoint == h["endpoint"]
+                and flask.request.view_args == h["view_args"]
+            )
 
-            h['url'] = flask.url_for(h['endpoint'],**h['view_args'])
-            a = flask.request.endpoint == h['endpoint']
-            b = flask.request.view_args == h['view_args']
-            h['active'] = flask.request.endpoint == h['endpoint'] and flask.request.view_args == h['view_args']
-
-
-    return { "headerDataL": headerDataL,
-             "headerDataR": headerDataR,
-             'hasLogout': 'auth.logout' in flask.current_app.view_functions
+    return {
+        "headerDataL": headerDataL,
+        "headerDataR": headerDataR,
+        "hasLogout": "auth.logout" in flask.current_app.view_functions,
     }
+
 
 @bp.route("/")
 def index():
-    return flask.render_template('index.html')
+    return flask.render_template("index.html")
+
 
 @bp.route("/bookings/<string:report>")
-@bp.route("/bookings", defaults={"report": "" })
+@bp.route("/bookings", defaults={"report": ""})
 def bookings(report):
-
     if report == "report" and not flask.g.isAdmin:
         flask.abort(403)
 
-    return flask.render_template('bookings.html',
-        report = (report == "report"),
-        maxReportRows = flask.current_app.config['MAX_REPORT_ROWS'])
+    return flask.render_template(
+        "bookings.html",
+        report=(report == "report"),
+        maxReportRows=flask.current_app.config["MAX_REPORT_ROWS"],
+    )
+
 
 @bp.route("/zone/<zid>")
 def zone(zid):
-
-    zoneRole = UserToZoneRoles.select(UserToZoneRoles.zone_role) \
-                              .where( (UserToZoneRoles.zid == zid) & (UserToZoneRoles.login == flask.g.login) ) \
-                              .scalar()
+    zoneRole = (
+        UserToZoneRoles.select(UserToZoneRoles.zone_role)
+        .where((UserToZoneRoles.zid == zid) & (UserToZoneRoles.login == flask.g.login))
+        .scalar()
+    )
 
     if zoneRole is None:
         flask.abort(403)
 
     nextWeek = utils.getNextWeek()
-    defaultSelectedDates = {
-        "slider": [9*3600, 17*3600]
-    }
+    defaultSelectedDates = {"slider": [9 * 3600, 17 * 3600]}
 
     for d in nextWeek[1:]:
-        if not d['isWeekend']:
-            defaultSelectedDates['cb'] = [d['timestamp']]
+        if not d["isWeekend"]:
+            defaultSelectedDates["cb"] = [d["timestamp"]]
             break
 
     if zoneRole <= ZONE_ROLE_ADMIN:
-        zoneRole = {'isZoneAdmin': True}
+        zoneRole = {"isZoneAdmin": True}
     elif zoneRole <= ZONE_ROLE_USER:
         zoneRole = {}
     elif zoneRole <= ZONE_ROLE_VIEWER:
-        zoneRole = {'isZoneViewer': True}
+        zoneRole = {"isZoneViewer": True}
     else:
-        raise Exception('Undefined role')
+        raise Exception("Undefined role")
 
-
-    return flask.render_template('zone.html',
+    return flask.render_template(
+        "zone.html",
         **zoneRole,
-        zid = zid,
+        zid=zid,
         nextWeek=nextWeek,
-        defaultSelectedDates=defaultSelectedDates)
+        defaultSelectedDates=defaultSelectedDates
+    )
+
 
 @bp.route("/zone/image/<zid>")
 def zoneImage(zid):
-
     if not flask.g.isAdmin:
-
-        zoneRole = UserToZoneRoles.select(UserToZoneRoles.zone_role) \
-                                .where( (UserToZoneRoles.zid == zid) & (UserToZoneRoles.login == flask.g.login) ) \
-                                .scalar()
+        zoneRole = (
+            UserToZoneRoles.select(UserToZoneRoles.zone_role)
+            .where((UserToZoneRoles.zid == zid) & (UserToZoneRoles.login == flask.g.login))
+            .scalar()
+        )
         if zoneRole is None:
             flask.abort(403)
 
-    blobIdQuery = Zone.select(Zone.iid.alias('id')).where(Zone.id == zid)
+    blobIdQuery = Zone.select(Zone.iid.alias("id")).where(Zone.id == zid)
 
     return blob_storage.createBlobResponse(blobIdQuery=blobIdQuery)
 
 
 @bp.route("/users")
 def users():
-
     if not flask.g.isAdmin:
         flask.abort(403)
 
-    return flask.render_template('users.html')
+    return flask.render_template("users.html")
+
 
 @bp.route("/groups")
 def groups():
-
     if not flask.g.isAdmin:
         flask.abort(403)
 
-    return flask.render_template('groups.html')
+    return flask.render_template("groups.html")
+
 
 @bp.route("/zones")
 def zones():
-
     if not flask.g.isAdmin:
         flask.abort(403)
 
-    return flask.render_template('zones.html')
+    return flask.render_template("zones.html")
 
 
 @bp.route("/groups/assign/<group_login>")
 def groupAssign(group_login):
-
     if not flask.g.isAdmin:
         flask.abort(403)
 
-    groupName = Users.select(Users.name) \
-                     .where( (Users.login == group_login) & (Users.account_type >= ACCOUNT_TYPE_GROUP) ) \
-                     .scalar()
+    groupName = (
+        Users.select(Users.name)
+        .where((Users.login == group_login) & (Users.account_type >= ACCOUNT_TYPE_GROUP))
+        .scalar()
+    )
 
     if groupName is None:
         flask.abort(404)
 
-    returnURL = flask.request.args.get('return',flask.url_for('view.groups'))
+    returnURL = flask.request.args.get("return", flask.url_for("view.groups"))
 
-    return flask.render_template('group_assign.html',
-                    groupLogin = group_login,
-                    groupName = groupName,
-                    returnURL = returnURL)
+    return flask.render_template(
+        "group_assign.html", groupLogin=group_login, groupName=groupName, returnURL=returnURL
+    )
 
 
 @bp.route("/zones/assign/<zid>")
 def zoneAssign(zid):
-
     if not flask.g.isAdmin:
         flask.abort(403)
 
-    zoneName = Zone.select(Zone.name) \
-                     .where( Zone.id == zid ) \
-                     .scalar()
+    zoneName = Zone.select(Zone.name).where(Zone.id == zid).scalar()
 
     if zoneName is None:
         flask.abort(404)
 
-    returnURL = flask.request.args.get('return',flask.url_for('view.zones'))
+    returnURL = flask.request.args.get("return", flask.url_for("view.zones"))
 
-    return flask.render_template('zone_assign.html',
-                    zoneName = zoneName,
-                    zid = zid,
-                    returnURL = returnURL)
+    return flask.render_template(
+        "zone_assign.html", zoneName=zoneName, zid=zid, returnURL=returnURL
+    )
+
 
 @bp.route("/zones/modify/<zid>")
 def zoneModify(zid):
-
     if not flask.g.isAdmin:
         flask.abort(403)
 
-    returnURL = flask.request.args.get('return',flask.url_for('view.zones'))
+    returnURL = flask.request.args.get("return", flask.url_for("view.zones"))
 
-    return flask.render_template('zone_modify.html',
-                    zid = zid,
-                    returnURL = returnURL)
+    return flask.render_template("zone_modify.html", zid=zid, returnURL=returnURL)

--- a/warp/view.py
+++ b/warp/view.py
@@ -1,8 +1,15 @@
 import flask
 
-from warp.db import *
-
 from . import blob_storage, utils
+from .db import (
+    ACCOUNT_TYPE_GROUP,
+    ZONE_ROLE_ADMIN,
+    ZONE_ROLE_USER,
+    ZONE_ROLE_VIEWER,
+    Users,
+    UserToZoneRoles,
+    Zone,
+)
 
 bp = flask.Blueprint("view", __name__)
 

--- a/warp/xhr/__init__.py
+++ b/warp/xhr/__init__.py
@@ -1,12 +1,8 @@
 import flask
 
-from . import bookings
-from . import zone
-from . import users
-from . import groups
-from . import zones
+from . import bookings, groups, users, zone, zones
 
-bp = flask.Blueprint('xhr', __name__)
+bp = flask.Blueprint("xhr", __name__)
 
 bp.register_blueprint(bookings.bp)
 bp.register_blueprint(zone.bp)

--- a/warp/xhr/bookings.py
+++ b/warp/xhr/bookings.py
@@ -1,13 +1,11 @@
 import io
 
 import flask
-import peewee
 import xlsxwriter
-from jsonschema import ValidationError, validate
 
-from warp import utils
-from warp.db import *
-from warp.utils_tabulator import *
+from .. import utils
+from ..db import ZONE_ROLE_ADMIN, ZONE_ROLE_USER, Book, Seat, Users, UserToZoneRoles, Zone
+from ..utils_tabulator import addToTabulatorSchema, applyTabulatorToQuery
 
 bp = flask.Blueprint("bookings", __name__, url_prefix="bookings")
 

--- a/warp/xhr/bookings.py
+++ b/warp/xhr/bookings.py
@@ -1,76 +1,88 @@
+import io
+
 import flask
 import peewee
 import xlsxwriter
-import io
-from jsonschema import validate, ValidationError
+from jsonschema import ValidationError, validate
 
-from warp.db import *
 from warp import utils
+from warp.db import *
 from warp.utils_tabulator import *
 
-bp = flask.Blueprint('bookings', __name__, url_prefix='bookings')
+bp = flask.Blueprint("bookings", __name__, url_prefix="bookings")
+
 
 @bp.route("report", methods=["POST"])
 def report():
     return listW(True)
 
-listSchema = addToTabulatorSchema({
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "properties": {
-        "export": {"enum": ["xlsx"] },
-        "filter": {    #this just extends the default tabulator schema for "function" filter
-            "items": {
-                "properties": {
-                    "type" : {"enum" : ["function"] }
-                },
-                "allOf": [
-                    {
-                        "if": {
-                            "properties": { "type" : {"enum" : ["function"] } }
-                        },
-                        "then": {
-                            "properties": {
-                                "value" : {
-                                    "type" : "object",
-                                    "properties": {
-                                        "fromts" : {"type" : ["integer","null"]},
-                                        "tots" : {"type" : ["integer","null"]}
+
+listSchema = addToTabulatorSchema(
+    {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "export": {"enum": ["xlsx"]},
+            "filter": {  # this just extends the default tabulator schema for "function" filter
+                "items": {
+                    "properties": {"type": {"enum": ["function"]}},
+                    "allOf": [
+                        {
+                            "if": {"properties": {"type": {"enum": ["function"]}}},
+                            "then": {
+                                "properties": {
+                                    "value": {
+                                        "type": "object",
+                                        "properties": {
+                                            "fromts": {"type": ["integer", "null"]},
+                                            "tots": {"type": ["integer", "null"]},
+                                        },
                                     }
                                 }
-                            }
-                        }
-                    },
-                ],
+                            },
+                        },
+                    ],
+                },
             },
         },
-    },
-})
+    }
+)
 
-@bp.route("list", endpoint='list', methods=["POST"])
+
+@bp.route("list", endpoint="list", methods=["POST"])
 @utils.validateJSONInput(listSchema)
-def listW(report = False):      # list is a built-in type
-
+def listW(report=False):  # list is a built-in type
     if not flask.g.isAdmin and report:
         flask.abort(403)
 
     requestData = flask.request.get_json()
 
-    if not report and 'export' in requestData:
+    if not report and "export" in requestData:
         flask.abort(403)
 
-    query = Book.select(Book.id, Users.name.alias('user_name'), Users.login, Zone.name.alias('zone_name'), Seat.name.alias('seat_name'), Book.fromts, Book.tots) \
-                      .join(Seat, on=(Book.sid == Seat.id)) \
-                      .join(Zone, on=(Seat.zid == Zone.id)) \
-                      .join(Users, on=(Book.login == Users.login))
+    query = (
+        Book.select(
+            Book.id,
+            Users.name.alias("user_name"),
+            Users.login,
+            Zone.name.alias("zone_name"),
+            Seat.name.alias("seat_name"),
+            Book.fromts,
+            Book.tots,
+        )
+        .join(Seat, on=(Book.sid == Seat.id))
+        .join(Zone, on=(Seat.zid == Zone.id))
+        .join(Users, on=(Book.login == Users.login))
+    )
 
     # user restrictions (in non-report mode)
     # visibility only on assigned zones and not in the past
     if not report:
-
-        query = query.select_extend(UserToZoneRoles.zone_role) \
-                     .join(UserToZoneRoles, on=(UserToZoneRoles.zid == Seat.zid)) \
-                     .where( (UserToZoneRoles.login == flask.g.login) & (Book.fromts >= utils.today()) )
+        query = (
+            query.select_extend(UserToZoneRoles.zone_role)
+            .join(UserToZoneRoles, on=(UserToZoneRoles.zid == Seat.zid))
+            .where((UserToZoneRoles.login == flask.g.login) & (Book.fromts >= utils.today()))
+        )
 
     columnsMap = {
         "id": Book.id,
@@ -79,61 +91,57 @@ def listW(report = False):      # list is a built-in type
         "zone_name": Zone.name,
         "seat_name": Seat.name,
         "fromTS": Book.fromts,
-        "toTS": Book.tots
+        "toTS": Book.tots,
     }
 
-    def funOperator(field,value):
-
-        from functools import reduce
+    def funOperator(field, value):
         import operator
+        from functools import reduce
 
-        if not isinstance(value,dict) or field.name != 'fromts':
+        if not isinstance(value, dict) or field.name != "fromts":
             return True
 
         expressions = []
-        if 'fromTS' in value and value['fromTS'] != None:
-            expressions.append( Book.fromts >= value['fromTS'])
-        if 'toTS' in value and value['toTS'] != None:
-            expressions.append( Book.tots <= value['toTS'])
+        if "fromTS" in value and value["fromTS"] != None:
+            expressions.append(Book.fromts >= value["fromTS"])
+        if "toTS" in value and value["toTS"] != None:
+            expressions.append(Book.tots <= value["toTS"])
 
         return reduce(operator.and_, expressions)
 
-
-    (query,lastPage) = applyTabulatorToQuery(query, requestData, columnsMap, funOperator)
+    (query, lastPage) = applyTabulatorToQuery(query, requestData, columnsMap, funOperator)
 
     if "export" in requestData:
-
         # this is already checked, but ...
         if not flask.g.isAdmin:
             flask.abort(403)
 
         # apply limit, clear offset (just in case)
-        query = query.offset().limit(flask.current_app.config['MAX_REPORT_ROWS'])
+        query = query.offset().limit(flask.current_app.config["MAX_REPORT_ROWS"])
 
         # only xlsx for now
         memoryBuffer = io.BytesIO()
 
-        workbook = xlsxwriter.Workbook(memoryBuffer, {'in_memory': True})
+        workbook = xlsxwriter.Workbook(memoryBuffer, {"in_memory": True})
         worksheet = workbook.add_worksheet()
 
         # TODO_TR
-        columnsHeader = [ "User name", "Login", "Zone name", "Seat name", "From", "To" ]
-        columnsContent = [ "user_name", "login", "zone_name", "seat_name", "fromts", "tots" ]
+        columnsHeader = ["User name", "Login", "Zone name", "Seat name", "From", "To"]
+        columnsContent = ["user_name", "login", "zone_name", "seat_name", "fromts", "tots"]
 
-        worksheet.write_row(0,0,columnsHeader)
+        worksheet.write_row(0, 0, columnsHeader)
 
-        for rowNo,dbRow in enumerate(query.iterator(),1):
-
+        for rowNo, dbRow in enumerate(query.iterator(), 1):
             rowData = []
             for i in columnsContent:
                 if i[-2:] == "ts":
-                    rowData.append( (dbRow[i] / 86400)+25569 )
+                    rowData.append((dbRow[i] / 86400) + 25569)
                 else:
                     rowData.append(dbRow[i])
 
-            worksheet.write_row(rowNo,0,rowData)
+            worksheet.write_row(rowNo, 0, rowData)
 
-        dateFormat = workbook.add_format({'num_format': 'yyyy-mm-dd hh:mm'})
+        dateFormat = workbook.add_format({"num_format": "yyyy-mm-dd hh:mm"})
         for colNo, col in enumerate(columnsContent):
             if col[-2:] == "ts":
                 worksheet.set_column(colNo, colNo, None, dateFormat)
@@ -145,38 +153,33 @@ def listW(report = False):      # list is a built-in type
         return flask.send_file(
             memoryBuffer,
             mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            download_name="warp_export.xlsx"
+            download_name="warp_export.xlsx",
         )
 
     else:
-
-        res = {
-            "data":[]
-        }
+        res = {"data": []}
 
         if lastPage is not None:
             res["last_page"] = lastPage
 
         for row in query:
-
             d = {
                 "id": row["id"],
                 "user_name": row["user_name"],
                 "zone_name": row["zone_name"],
                 "seat_name": row["seat_name"],
                 "fromTS": row["fromts"],
-                "toTS": row["tots"]
+                "toTS": row["tots"],
             }
 
             if not report:
-
-                d['rw'] = \
-                    (row["login"] == flask.g.login and row["zone_role"] <= ZONE_ROLE_USER) \
-                    or row["zone_role"] <= ZONE_ROLE_ADMIN
+                d["rw"] = (
+                    row["login"] == flask.g.login and row["zone_role"] <= ZONE_ROLE_USER
+                ) or row["zone_role"] <= ZONE_ROLE_ADMIN
 
             else:
                 d["login"] = row["login"]
 
-            res['data'].append(d)
+            res["data"].append(d)
 
         return flask.jsonify(res)

--- a/warp/xhr/groups.py
+++ b/warp/xhr/groups.py
@@ -1,9 +1,8 @@
 import flask
-from jsonschema import ValidationError, validate
 
-from warp import utils
-from warp.db import *
-from warp.utils_tabulator import *
+from .. import utils
+from ..db import ACCOUNT_TYPE_GROUP, DB, Groups, IntegrityError, Users
+from ..utils_tabulator import addToTabulatorSchema, applyTabulatorToQuery
 
 bp = flask.Blueprint("groups", __name__, url_prefix="groups")
 

--- a/warp/xhr/groups.py
+++ b/warp/xhr/groups.py
@@ -1,40 +1,41 @@
 import flask
-from jsonschema import validate, ValidationError
+from jsonschema import ValidationError, validate
 
-from warp.db import *
 from warp import utils
+from warp.db import *
 from warp.utils_tabulator import *
 
-bp = flask.Blueprint('groups', __name__, url_prefix='groups')
+bp = flask.Blueprint("groups", __name__, url_prefix="groups")
 
-membersSchema = addToTabulatorSchema({
-    "properties": {
-        "groupLogin": {"type": "string"},
-    },
-    "required": ["groupLogin"],
-})
+membersSchema = addToTabulatorSchema(
+    {
+        "properties": {
+            "groupLogin": {"type": "string"},
+        },
+        "required": ["groupLogin"],
+    }
+)
+
 
 @bp.route("members", methods=["POST"])
-@utils.validateJSONInput(membersSchema,isAdmin=True)
+@utils.validateJSONInput(membersSchema, isAdmin=True)
 def members():
-
     requestData = flask.request.get_json()
 
-    query = Groups.select(Users.login, Users.name, Users.account_type) \
-                  .join(Users, on=(Groups.login == Users.login)) \
-                  .where(Groups.group == requestData['groupLogin']) \
-                  .tuples()
+    query = (
+        Groups.select(Users.login, Users.name, Users.account_type)
+        .join(Users, on=(Groups.login == Users.login))
+        .where(Groups.group == requestData["groupLogin"])
+        .tuples()
+    )
 
-    (query, lastPage) = applyTabulatorToQuery(query,requestData)
+    (query, lastPage) = applyTabulatorToQuery(query, requestData)
 
     res = {
         "data": [
-            {
-                "login": d[0],
-                "name": d[1],
-                "isGroup": d[2] >= ACCOUNT_TYPE_GROUP
-            } for d in query.iterator()
-         ]
+            {"login": d[0], "name": d[1], "isGroup": d[2] >= ACCOUNT_TYPE_GROUP}
+            for d in query.iterator()
+        ]
     }
 
     if lastPage is not None:
@@ -42,26 +43,25 @@ def members():
 
     return flask.jsonify(res)
 
+
 assignSchema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "groupLogin": {"type": "string"},
-        "add" : {
-            "type" : "array",
-            "items": { "type": "string" },
-            },
-        "remove" : {
-            "type" : "array",
-            "items": { "type": "string" },
-            },
+        "add": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "remove": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
     },
     "required": ["groupLogin"],
-    "anyOf": [
-        {"required": ["add"]},
-        {"required": ["remove"]}
-    ]
+    "anyOf": [{"required": ["add"]}, {"required": ["remove"]}],
 }
+
 
 # Format
 # {
@@ -69,34 +69,28 @@ assignSchema = {
 #   remove: [ login1, login2, ...]
 # }
 @bp.route("assign", methods=["POST"])
-@utils.validateJSONInput(assignSchema,isAdmin=True)
+@utils.validateJSONInput(assignSchema, isAdmin=True)
 def assign():
-
     action_data = flask.request.get_json()
 
     with DB.atomic():
-
-        if 'remove' in action_data:
-
+        if "remove" in action_data:
             try:
-
-                Groups.delete() \
-                      .where(Groups.group == action_data['groupLogin']) \
-                      .where(Groups.login.in_(action_data['remove'])) \
-                      .execute()
+                Groups.delete().where(Groups.group == action_data["groupLogin"]).where(
+                    Groups.login.in_(action_data["remove"])
+                ).execute()
 
             except IntegrityError as err:
-                return {"msg": "Error", "code": 212 }, 400
+                return {"msg": "Error", "code": 212}, 400
 
-
-        if 'add' in action_data:
-
+        if "add" in action_data:
             try:
-                insData = [ {"group": action_data['groupLogin'], "login": x } for x in action_data['add'] ]
+                insData = [
+                    {"group": action_data["groupLogin"], "login": x} for x in action_data["add"]
+                ]
                 Groups.insert(insData).on_conflict_ignore().execute()
 
             except IntegrityError as err:
-                return {"msg": "Error", "code": 213 }, 400
+                return {"msg": "Error", "code": 213}, 400
 
-    return {"msg": "ok" }, 200
-
+    return {"msg": "ok"}, 200

--- a/warp/xhr/users.py
+++ b/warp/xhr/users.py
@@ -1,60 +1,63 @@
 import flask
-from jsonschema import validate, ValidationError
 import orjson
+from jsonschema import ValidationError, validate
 
-from warp.db import *
 from warp import utils
+from warp.db import *
 from warp.utils_tabulator import *
 
-bp = flask.Blueprint('users', __name__, url_prefix='users')
+bp = flask.Blueprint("users", __name__, url_prefix="users")
 
-@bp.route("list", endpoint='list', methods=["POST"])
-@utils.validateJSONInput(tabulatorSchema,isAdmin=True)
-def listW(report = False):              #list is a built-in type
 
+@bp.route("list", endpoint="list", methods=["POST"])
+@utils.validateJSONInput(tabulatorSchema, isAdmin=True)
+def listW(report=False):  # list is a built-in type
     requestData = flask.request.get_json()
 
     query = Users.select(Users.login, Users.name, Users.account_type)
 
-    (query, lastPage) = applyTabulatorToQuery(query,requestData)
+    (query, lastPage) = applyTabulatorToQuery(query, requestData)
 
-    res = {
-        "data": [ *query.iterator() ]
-    }
+    res = {"data": [*query.iterator()]}
 
     if lastPage is not None:
         res["last_page"] = lastPage
 
     return flask.current_app.response_class(
-        response=orjson.dumps(res),
-        status=200,
-        mimetype='application/json')
+        response=orjson.dumps(res), status=200, mimetype="application/json"
+    )
+
 
 editSchema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "login" : {"type" : "string"},
-        "name" : {"type" : "string"},
-        "account_type" : {"enum" : [ACCOUNT_TYPE_ADMIN,ACCOUNT_TYPE_USER,ACCOUNT_TYPE_BLOCKED,ACCOUNT_TYPE_GROUP]},
-        "password" : {"type" : "string"},
-        "action": {"enum": ["add","update"]},
+        "login": {"type": "string"},
+        "name": {"type": "string"},
+        "account_type": {
+            "enum": [
+                ACCOUNT_TYPE_ADMIN,
+                ACCOUNT_TYPE_USER,
+                ACCOUNT_TYPE_BLOCKED,
+                ACCOUNT_TYPE_GROUP,
+            ]
+        },
+        "password": {"type": "string"},
+        "action": {"enum": ["add", "update"]},
         "groups": {
             "type": "array",
-            "items": {
-                "type": "string"
-            },
-        }
+            "items": {"type": "string"},
+        },
     },
-    "required": [ "login", "action", "name", "account_type"]
+    "required": ["login", "action", "name", "account_type"],
 }
+
 
 # Format:
 # { login: login, name: name, account_type: account_type, password: plain_text, action: "add|update" }
 @bp.route("edit", methods=["POST"])
-@utils.validateJSONInput(editSchema,isAdmin=True)
+@utils.validateJSONInput(editSchema, isAdmin=True)
 def edit():
-
     from werkzeug.security import generate_password_hash
 
     action_data = flask.request.get_json()
@@ -64,124 +67,109 @@ def edit():
 
     try:
         with DB.atomic():
-
             updColumns = {
-                Users.name: action_data['name'],
-                Users.account_type: action_data['account_type'],
+                Users.name: action_data["name"],
+                Users.account_type: action_data["account_type"],
             }
 
-            if len(action_data.get('password','')) > 0 and action_data['account_type'] < ACCOUNT_TYPE_GROUP:
-                updColumns[Users.password] = generate_password_hash(action_data['password'])
+            if (
+                len(action_data.get("password", "")) > 0
+                and action_data["account_type"] < ACCOUNT_TYPE_GROUP
+            ):
+                updColumns[Users.password] = generate_password_hash(action_data["password"])
 
-            if action_data['action'] == "update":
-
-                updateQ = Users.update(updColumns) \
-                                .where(Users.login == action_data['login'])
+            if action_data["action"] == "update":
+                updateQ = Users.update(updColumns).where(Users.login == action_data["login"])
 
                 # prevent conversion from User <=> Group
-                if updColumns[ Users.account_type ] < ACCOUNT_TYPE_GROUP:
-                    updateQ = updateQ.where( Users.account_type < ACCOUNT_TYPE_GROUP)
+                if updColumns[Users.account_type] < ACCOUNT_TYPE_GROUP:
+                    updateQ = updateQ.where(Users.account_type < ACCOUNT_TYPE_GROUP)
                 else:
-                    updateQ = updateQ.where( Users.account_type >= ACCOUNT_TYPE_GROUP)
+                    updateQ = updateQ.where(Users.account_type >= ACCOUNT_TYPE_GROUP)
 
                 rowCount = updateQ.execute()
 
                 if rowCount != 1:
                     raise ApplyError("Wrong number of affected rows", 153)
 
-            elif action_data['action'] == "add":
-
-                updColumns[Users.login] = action_data['login'],
+            elif action_data["action"] == "add":
+                updColumns[Users.login] = (action_data["login"],)
                 Users.insert(updColumns).execute()
 
-            if 'groups' in action_data:
+            if "groups" in action_data:
+                Groups.delete().where(Groups.login == action_data["login"]).execute()
 
-                Groups.delete() \
-                    .where(Groups.login == action_data['login']) \
-                    .execute()
-
-                gr = [{
-                        Groups.login: action_data['login'],
-                        Groups.group: i
-                    } for i in action_data['groups']
+                gr = [
+                    {Groups.login: action_data["login"], Groups.group: i}
+                    for i in action_data["groups"]
                 ]
 
                 if len(gr):
-                    Groups.insert(gr) \
-                        .on_conflict_ignore() \
-                        .execute()
+                    Groups.insert(gr).on_conflict_ignore().execute()
 
     except IntegrityError as err:
-        if action_data['action'] == "add":
-            return {"msg": "Login exits", "code": 155 }, 400
+        if action_data["action"] == "add":
+            return {"msg": "Login exits", "code": 155}, 400
         else:
-            return {"msg": "Error", "code": 156 }, 400
+            return {"msg": "Error", "code": 156}, 400
     except ApplyError as err:
-        return {"msg": "Error", "code": err.args[1] }, 400
+        return {"msg": "Error", "code": err.args[1]}, 400
 
-    return {"msg": "ok" }, 200
+    return {"msg": "ok"}, 200
 
 
 deleteSchema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "properties": {
-        "login" : {"type" : "string"},
-        "force": {"type": "boolean"}
-    },
-    "required": [ "login" ]
+    "properties": {"login": {"type": "string"}, "force": {"type": "boolean"}},
+    "required": ["login"],
 }
+
 
 # Format:
 # { login: login, force: true|false }
 @bp.route("delete", methods=["POST"])
-@utils.validateJSONInput(deleteSchema,isAdmin=True)
+@utils.validateJSONInput(deleteSchema, isAdmin=True)
 def delete():
-
     action_data = flask.request.get_json()
 
-    login = action_data['login']
-    force = action_data.get('force', False)
+    login = action_data["login"]
+    force = action_data.get("force", False)
 
     if not force:
         today = utils.today()
 
-        rowCount = Book.select(COUNT_STAR) \
-                       .where(Book.login == login) \
-                       .where(Book.fromts < today) \
-                       .scalar()
+        rowCount = (
+            Book.select(COUNT_STAR).where(Book.login == login).where(Book.fromts < today).scalar()
+        )
 
         if rowCount:
             return {"msg": "User has past bookings", "bookCount": rowCount, "code": 173}, 406
 
     try:
         with DB.atomic():
-
             # rowCount ?
-            Users.delete().where(Users.login == login) \
-                 .execute()
+            Users.delete().where(Users.login == login).execute()
 
     except IntegrityError:
-        return {"msg": "Error", "code":  174}, 400
+        return {"msg": "Error", "code": 174}, 400
 
-    return {"msg": "ok" }, 200
+    return {"msg": "ok"}, 200
 
 
 @bp.route("groups/<login>")
 def groups(login):
-
     if not flask.g.isAdmin:
-        return {"msg":"Forbidden", "code": 175}, 403
+        return {"msg": "Forbidden", "code": 175}, 403
 
-    query = Groups.select(Users.login, Users.name) \
-        .join(Users, on=(Groups.group == Users.login)) \
+    query = (
+        Groups.select(Users.login, Users.name)
+        .join(Users, on=(Groups.group == Users.login))
         .where(Groups.login == login)
+    )
 
-    res = [ *query.iterator() ]
+    res = [*query.iterator()]
 
     return flask.current_app.response_class(
-        response=orjson.dumps(res),
-        status=200,
-        mimetype='application/json')
-
-
+        response=orjson.dumps(res), status=200, mimetype="application/json"
+    )

--- a/warp/xhr/users.py
+++ b/warp/xhr/users.py
@@ -1,10 +1,20 @@
 import flask
 import orjson
-from jsonschema import ValidationError, validate
 
-from warp import utils
-from warp.db import *
-from warp.utils_tabulator import *
+from .. import utils
+from ..db import (
+    ACCOUNT_TYPE_ADMIN,
+    ACCOUNT_TYPE_BLOCKED,
+    ACCOUNT_TYPE_GROUP,
+    ACCOUNT_TYPE_USER,
+    COUNT_STAR,
+    DB,
+    Book,
+    Groups,
+    IntegrityError,
+    Users,
+)
+from ..utils_tabulator import applyTabulatorToQuery, tabulatorSchema
 
 bp = flask.Blueprint("users", __name__, url_prefix="users")
 

--- a/warp/xhr/zone.py
+++ b/warp/xhr/zone.py
@@ -3,10 +3,20 @@ from collections import defaultdict
 import flask
 import orjson
 import peewee
-from jsonschema import ValidationError, validate
 
-from warp import auth, utils
-from warp.db import *
+from .. import utils
+from ..db import (
+    COUNT_STAR,
+    DB,
+    SQL_ONE,
+    ZONE_ROLE_ADMIN,
+    Book,
+    Seat,
+    SeatAssign,
+    Users,
+    UserToZoneRoles,
+    Zone,
+)
 
 bp = flask.Blueprint("zone", __name__, url_prefix="zone")
 

--- a/warp/xhr/zone.py
+++ b/warp/xhr/zone.py
@@ -1,16 +1,17 @@
 from collections import defaultdict
+
 import flask
-from jsonschema import validate, ValidationError
 import orjson
 import peewee
+from jsonschema import ValidationError, validate
 
-from warp import auth
-from warp import utils
+from warp import auth, utils
 from warp.db import *
 
-bp = flask.Blueprint('zone', __name__, url_prefix='zone')
+bp = flask.Blueprint("zone", __name__, url_prefix="zone")
 
-#Format JSON
+
+# Format JSON
 #   zones: {
 #       zidN: "Zone name" }
 #   users: {
@@ -37,136 +38,131 @@ bp = flask.Blueprint('zone', __name__, url_prefix='zone')
 #   onlyOtherZone=0|1 - returns only zones, users for other zones (sidM...)
 @bp.route("getSeats/<int:zid>")
 def getSeats(zid):
+    res = {"seats": {}}
 
-    res = {
-        "seats": {}
-    }
-
-    zoneRole = UserToZoneRoles.select(UserToZoneRoles.zone_role) \
-                              .where( (UserToZoneRoles.zid == zid) & (UserToZoneRoles.login == flask.g.login) ) \
-                              .scalar()
+    zoneRole = (
+        UserToZoneRoles.select(UserToZoneRoles.zone_role)
+        .where((UserToZoneRoles.zid == zid) & (UserToZoneRoles.login == flask.g.login))
+        .scalar()
+    )
 
     if zoneRole is None:
-        return {"msg": "Forbidden", "code": 130 }, 403
+        return {"msg": "Forbidden", "code": 130}, 403
 
-    if ('login' in flask.request.args or 'onlyOtherZone' in flask.request.args):
-
+    if "login" in flask.request.args or "onlyOtherZone" in flask.request.args:
         if zoneRole > ZONE_ROLE_ADMIN:
-            return {"msg": "Forbidden", "code": 131 }, 403
+            return {"msg": "Forbidden", "code": 131}, 403
 
-        isLoginInZone = UserToZoneRoles.select(UserToZoneRoles.zone_role) \
-                              .where(UserToZoneRoles.zid == zid) \
-                              .where(UserToZoneRoles.login == flask.request.args.get('login') ) \
-                              .scalar()
+        isLoginInZone = (
+            UserToZoneRoles.select(UserToZoneRoles.zone_role)
+            .where(UserToZoneRoles.zid == zid)
+            .where(UserToZoneRoles.login == flask.request.args.get("login"))
+            .scalar()
+        )
 
         if isLoginInZone is None:
-            return {"msg": "Forbidden", "code": 132 }, 403
+            return {"msg": "Forbidden", "code": 132}, 403
 
     tr = utils.getTimeRange()
     usedZones = set()
     usedUsers = set()
 
-    if flask.request.args.get('onlyOtherZone') not in {'1','True','true'}:
-
-        assignCursor = SeatAssign.select(SeatAssign.sid, Users.login) \
-                                .join(Users,on=(SeatAssign.login == Users.login)) \
-                                .join(Seat, on=(SeatAssign.sid == Seat.id)) \
-                                .where(Seat.zid == zid)
+    if flask.request.args.get("onlyOtherZone") not in {"1", "True", "true"}:
+        assignCursor = (
+            SeatAssign.select(SeatAssign.sid, Users.login)
+            .join(Users, on=(SeatAssign.login == Users.login))
+            .join(Seat, on=(SeatAssign.sid == Seat.id))
+            .where(Seat.zid == zid)
+        )
 
         assignments = defaultdict(set)
         for r in assignCursor:
-            assignments[r['sid']].add(r['login'])
-            usedUsers.add(r['login'])
+            assignments[r["sid"]].add(r["login"])
+            usedUsers.add(r["login"])
 
-        seatsCursor = Seat.select(Seat.id, Seat.name, Seat.x, Seat.y, Seat.zid, Seat.enabled) \
-                            .where(Seat.zid == zid)
+        seatsCursor = Seat.select(Seat.id, Seat.name, Seat.x, Seat.y, Seat.zid, Seat.enabled).where(
+            Seat.zid == zid
+        )
 
         if zoneRole != ZONE_ROLE_ADMIN:
             seatsCursor = seatsCursor.where(Seat.enabled == True)
 
         for s in seatsCursor.iterator():
-
             seatD = {
-                "name": s['name'],
-                "x": s['x'],
-                "y": s['y'],
-                "zid": s['zid'],
-                "enabled": s['enabled'] != 0,
-                "book": []
+                "name": s["name"],
+                "x": s["x"],
+                "y": s["y"],
+                "zid": s["zid"],
+                "enabled": s["enabled"] != 0,
+                "book": [],
             }
 
-            if s['id'] in assignments:
-                seatD['assignments'] = [*assignments[s['id']]]
+            if s["id"] in assignments:
+                seatD["assignments"] = [*assignments[s["id"]]]
 
-            res['seats'][ str(s['id']) ] = seatD
+            res["seats"][str(s["id"])] = seatD
 
-
-        bookQuery = Book.select(Book.id, Book.login, Book.sid, Users.name.alias('username'), Book.fromts, Book.tots) \
-                            .join(Users, on=(Book.login == Users.login)) \
-                            .join(Seat, on=(Book.sid == Seat.id)) \
-                            .where((Book.fromts < tr['toTS']) & (Book.tots > tr['fromTS']) & (Seat.zid == zid)) \
-                            .order_by(Book.fromts)
+        bookQuery = (
+            Book.select(
+                Book.id, Book.login, Book.sid, Users.name.alias("username"), Book.fromts, Book.tots
+            )
+            .join(Users, on=(Book.login == Users.login))
+            .join(Seat, on=(Book.sid == Seat.id))
+            .where((Book.fromts < tr["toTS"]) & (Book.tots > tr["fromTS"]) & (Seat.zid == zid))
+            .order_by(Book.fromts)
+        )
 
         if zoneRole != ZONE_ROLE_ADMIN:
             bookQuery = bookQuery.where(Seat.enabled == True)
 
         for b in DB.execute(bookQuery):
-
             sid = str(b[2])
 
-            res['seats'][sid]['book'].append({
-                "bid": b[0],
-                "login": b[1],
-                "fromTS": b[4],
-                "toTS": b[5] })
+            res["seats"][sid]["book"].append(
+                {"bid": b[0], "login": b[1], "fromTS": b[4], "toTS": b[5]}
+            )
 
             usedUsers.add(b[1])
 
         usedZones.add(zid)
 
-    login = flask.request.args.get('login',flask.g.login)
+    login = flask.request.args.get("login", flask.g.login)
 
     # User should get all his conflicting bookings even if he is not assigned to the zone
     # this is useful in case of reassignment
     # Also user is not allowed to book in not-assigned zones, but he/she is allowed to delete
     # own bookings from not-assigned zones
-    otherZoneBookQuery = Book.select(Book.sid, Seat.name, Seat.zid, Book.id, Book.fromts, Book.tots) \
-                            .join(Seat, on=(Book.sid == Seat.id)) \
-                            .join(Zone, on=(Seat.zid == Zone.id)) \
-                            .where( (Seat.zid != zid) & (Seat.enabled == True) ) \
-                            .where(Zone.zone_group == ( \
-                                Zone.select(Zone.zone_group).where(Zone.id == zid)) ) \
-                            .where(Book.login == login) \
-                            .order_by(Book.fromts).tuples()
+    otherZoneBookQuery = (
+        Book.select(Book.sid, Seat.name, Seat.zid, Book.id, Book.fromts, Book.tots)
+        .join(Seat, on=(Book.sid == Seat.id))
+        .join(Zone, on=(Seat.zid == Zone.id))
+        .where((Seat.zid != zid) & (Seat.enabled == True))
+        .where(Zone.zone_group == (Zone.select(Zone.zone_group).where(Zone.id == zid)))
+        .where(Book.login == login)
+        .order_by(Book.fromts)
+        .tuples()
+    )
 
     for b in otherZoneBookQuery.iterator():
-
         sid = str(b[0])
 
-        if sid not in res['seats']:
-            res['seats'][sid] = {
-                "name": b[1],
-                "zid": b[2],
-                "book": []
-            }
+        if sid not in res["seats"]:
+            res["seats"][sid] = {"name": b[1], "zid": b[2], "book": []}
             usedZones.add(b[2])
 
-        res['seats'][sid]['book'].append({
-            "bid": b[3],
-            "fromTS": b[4],
-            "toTS": b[5]
-            })
+        res["seats"][sid]["book"].append({"bid": b[3], "fromTS": b[4], "toTS": b[5]})
 
-    usedZonesQuery = Zone.select(Zone.id,Zone.name).where(Zone.id.in_(usedZones)).tuples()
-    res['zones'] = {str(i[0]): i[1] for i in usedZonesQuery.iterator()}
+    usedZonesQuery = Zone.select(Zone.id, Zone.name).where(Zone.id.in_(usedZones)).tuples()
+    res["zones"] = {str(i[0]): i[1] for i in usedZonesQuery.iterator()}
 
-    usedUsersQuery = Users.select(Users.login, Users.name).where(Users.login.in_(usedUsers)).tuples()
-    res['users'] = {str(i[0]): i[1] for i in usedUsersQuery.iterator()}
+    usedUsersQuery = (
+        Users.select(Users.login, Users.name).where(Users.login.in_(usedUsers)).tuples()
+    )
+    res["users"] = {str(i[0]): i[1] for i in usedUsersQuery.iterator()}
 
     resR = flask.current_app.response_class(
-        response=orjson.dumps(res),
-        status=200,
-        mimetype='application/json')
+        response=orjson.dumps(res), status=200, mimetype="application/json"
+    )
 
     return resR
 
@@ -176,20 +172,16 @@ applySchema = {
     "properties": {
         "enable": {
             "type": "array",
-            "items": {
-                "type": "integer"
-            },
+            "items": {"type": "integer"},
         },
         "disable": {
             "type": "array",
-            "items": {
-                "type": "integer"
-            },
+            "items": {"type": "integer"},
         },
         "assign": {
             "type": "object",
             "properties": {
-                "sid" : {"type" : "integer"},
+                "sid": {"type": "integer"},
                 "logins": {
                     "type": "array",
                     "items": {
@@ -202,37 +194,30 @@ applySchema = {
             "type": "object",
             "properties": {
                 "login": {"type": "string"},
-                "sid" : {"type" : "integer"},
+                "sid": {"type": "integer"},
                 "dates": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "object",
-                        "properties": {
-                            "fromTS": {"type" : "integer"},
-                            "toTS": {"type" : "integer"}
-                        },
-                        "required": [ "fromTS", "toTS"]
-                    }
-                }
+                        "properties": {"fromTS": {"type": "integer"}, "toTS": {"type": "integer"}},
+                        "required": ["fromTS", "toTS"],
+                    },
+                },
             },
-            "required": [ "sid", "dates"],
+            "required": ["sid", "dates"],
         },
-        "remove": {
-            "type": "array",
-            "items": {
-                "type": "integer"
-            }
-        }
+        "remove": {"type": "array", "items": {"type": "integer"}},
     },
     "anyOf": [
-        {"required": [ "enable" ]},
-        {"required": [ "disable" ]},
-        {"required": [ "assign" ]},
-        {"required": [ "book" ]},
-        {"required": [ "remove" ]}
-    ]
+        {"required": ["enable"]},
+        {"required": ["disable"]},
+        {"required": ["assign"]},
+        {"required": ["book"]},
+        {"required": ["remove"]},
+    ],
 }
+
 
 # format:
 # {
@@ -255,7 +240,6 @@ applySchema = {
 @bp.route("apply", methods=["POST"])
 @utils.validateJSONInput(applySchema)
 def apply():
-
     apply_data = flask.request.get_json()
     ts = utils.getTimeRange()
 
@@ -265,63 +249,75 @@ def apply():
 
     # zone access
     seatsReqZoneAdmin = set()
-    if 'enable' in apply_data: seatsReqZoneAdmin.update(apply_data['enable'])
-    if 'disable' in apply_data: seatsReqZoneAdmin.update(apply_data['disable'])
-    if 'assign' in apply_data: seatsReqZoneAdmin.add(apply_data['assign']['sid'])
-    if 'book' in apply_data and 'login' in apply_data['book']: seatsReqZoneAdmin.add(apply_data['book']['sid'])
+    if "enable" in apply_data:
+        seatsReqZoneAdmin.update(apply_data["enable"])
+    if "disable" in apply_data:
+        seatsReqZoneAdmin.update(apply_data["disable"])
+    if "assign" in apply_data:
+        seatsReqZoneAdmin.add(apply_data["assign"]["sid"])
+    if "book" in apply_data and "login" in apply_data["book"]:
+        seatsReqZoneAdmin.add(apply_data["book"]["sid"])
 
-    if 'remove' in apply_data:
-
+    if "remove" in apply_data:
         # list non-owned bookings
         # user is always allowed to remove own bookings, even if is not assigned to the zone (or is just a viewer)
         # this hole allows user to update booking into allowed zone in case there is some left-over booking in another zone
-        removeQ = Book.select(Book.sid) \
-                      .where(Book.id.in_(apply_data['remove'])) \
-                      .where(Book.login != flask.g.login).tuples()
+        removeQ = (
+            Book.select(Book.sid)
+            .where(Book.id.in_(apply_data["remove"]))
+            .where(Book.login != flask.g.login)
+            .tuples()
+        )
 
-        seatsReqZoneAdmin.update( [ i[0] for i in removeQ.iterator() ] )
+        seatsReqZoneAdmin.update([i[0] for i in removeQ.iterator()])
 
     if seatsReqZoneAdmin:
-
-        count = Seat.select(COUNT_STAR) \
-                    .join(UserToZoneRoles, on=(Seat.zid == UserToZoneRoles.zid)) \
-                    .where(UserToZoneRoles.login == flask.g.login) \
-                    .where(Seat.id.in_(seatsReqZoneAdmin)) \
-                    .where(UserToZoneRoles.zone_role <= ZONE_ROLE_ADMIN) \
-                    .scalar()
+        count = (
+            Seat.select(COUNT_STAR)
+            .join(UserToZoneRoles, on=(Seat.zid == UserToZoneRoles.zid))
+            .where(UserToZoneRoles.login == flask.g.login)
+            .where(Seat.id.in_(seatsReqZoneAdmin))
+            .where(UserToZoneRoles.zone_role <= ZONE_ROLE_ADMIN)
+            .scalar()
+        )
 
         if count != len(seatsReqZoneAdmin):
-            return {"msg": "Forbidden", "code": 102 }, 403
+            return {"msg": "Forbidden", "code": 102}, 403
 
-    if 'book' in apply_data:
-
-        if not flask.g.isAdmin:     # TODO: should admin be allowed to do that?
-            for b in apply_data['book']['dates']:
-                if b['fromTS'] < ts["fromTS"] or b['fromTS'] > ts["toTS"] \
-                    or b['toTS'] < ts["fromTS"] or b['toTS'] > ts["toTS"]:
+    if "book" in apply_data:
+        if not flask.g.isAdmin:  # TODO: should admin be allowed to do that?
+            for b in apply_data["book"]["dates"]:
+                if (
+                    b["fromTS"] < ts["fromTS"]
+                    or b["fromTS"] > ts["toTS"]
+                    or b["toTS"] < ts["fromTS"]
+                    or b["toTS"] > ts["toTS"]
+                ):
                     return {"msg": "Forbidden", "code": 103}, 403
 
-        sid = apply_data['book']['sid']
-        login = apply_data['book'].get('login', flask.g.login)
+        sid = apply_data["book"]["sid"]
+        login = apply_data["book"].get("login", flask.g.login)
 
-        seat = Seat.select(Seat.enabled) \
-                    .join(UserToZoneRoles, on=(Seat.zid == UserToZoneRoles.zid)) \
-                    .where( (Seat.id == sid) & (UserToZoneRoles.login == login)) \
-                    .first()
+        seat = (
+            Seat.select(Seat.enabled)
+            .join(UserToZoneRoles, on=(Seat.zid == UserToZoneRoles.zid))
+            .where((Seat.id == sid) & (UserToZoneRoles.login == login))
+            .first()
+        )
 
         # login not in the zone
         if seat is None:
             return {"msg": "Forbidden", "code": 104}, 403
 
         # seat is disabled
-        if not seat['enabled']:
+        if not seat["enabled"]:
             return {"msg": "Forbidden", "code": 105}, 403
 
         # check if user is assigned to the seat
         assignedQ = SeatAssign.select(SQL_ONE).where(SeatAssign.sid == sid)
         assignedToMeQ = assignedQ.where(SeatAssign.login == login)
 
-        if (assignedQ.scalar() is not None and assignedToMeQ.scalar() is None):
+        if assignedQ.scalar() is not None and assignedToMeQ.scalar() is None:
             return {"msg": "Forbidden", "code": 106}, 403
 
     # -------------------------------------
@@ -332,106 +328,110 @@ def apply():
         pass
 
     try:
-
         with DB.atomic():
+            if "enable" in apply_data:
+                Seat.update({Seat.enabled: True}).where(Seat.id.in_(apply_data["enable"])).execute()
 
-            if 'enable' in apply_data:
+            if "disable" in apply_data:
+                Seat.update({Seat.enabled: False}).where(
+                    Seat.id.in_(apply_data["disable"])
+                ).execute()
 
-                Seat.update({Seat.enabled: True}).where(Seat.id.in_(apply_data['enable'])).execute()
+            if "assign" in apply_data:
+                SeatAssign.delete().where(SeatAssign.sid == apply_data["assign"]["sid"]).execute()
 
-            if 'disable' in apply_data:
-
-                Seat.update({Seat.enabled: False}).where(Seat.id.in_(apply_data['disable'])).execute()
-
-            if 'assign' in apply_data:
-
-                SeatAssign.delete().where(SeatAssign.sid == apply_data['assign']['sid']).execute()
-
-                if len(apply_data['assign']['logins']):
-
-                    insertData = [{
-                        SeatAssign.sid: apply_data['assign']['sid'],
-                        SeatAssign.login: l
-                        } for l in apply_data['assign']['logins']]
+                if len(apply_data["assign"]["logins"]):
+                    insertData = [
+                        {SeatAssign.sid: apply_data["assign"]["sid"], SeatAssign.login: l}
+                        for l in apply_data["assign"]["logins"]
+                    ]
 
                     rowCount = SeatAssign.insert(insertData).as_rowcount().execute()
 
-                    if rowCount != len(apply_data['assign']['logins']):
-                        raise ApplyError("Number of affected row is different then in assign.logins.", 107)
+                    if rowCount != len(apply_data["assign"]["logins"]):
+                        raise ApplyError(
+                            "Number of affected row is different then in assign.logins.", 107
+                        )
 
             # remove must be executed before book
-            if 'remove' in apply_data:
-
-                stmt = Book.delete().where(Book.id.in_(apply_data['remove']))
+            if "remove" in apply_data:
+                stmt = Book.delete().where(Book.id.in_(apply_data["remove"]))
                 rowCount = stmt.execute()
 
-                if rowCount != len(apply_data['remove']):
-                    raise ApplyError("Number of affected row is different then in remove.",108)
+                if rowCount != len(apply_data["remove"]):
+                    raise ApplyError("Number of affected row is different then in remove.", 108)
 
             # then we create new reservations
-            if 'book' in apply_data:
+            if "book" in apply_data:
+                sid = apply_data["book"]["sid"]
+                login = apply_data["book"].get("login", flask.g.login)
 
-                sid = apply_data['book']['sid']
-                login = apply_data['book'].get('login', flask.g.login)
-
-                insertData = [ {
+                insertData = [
+                    {
                         Book.login: login,
                         Book.sid: sid,
-                        Book.fromts: x['fromTS'],
-                        Book.tots: x['toTS']
-                    } for x in apply_data['book']['dates'] ]
+                        Book.fromts: x["fromTS"],
+                        Book.tots: x["toTS"],
+                    }
+                    for x in apply_data["book"]["dates"]
+                ]
 
                 stmt = Book.insert(insertData)
 
                 try:
                     stmt.execute()
                 except peewee.IntegrityError:
-                    raise ApplyError("Overlapping time",109)
-
+                    raise ApplyError("Overlapping time", 109)
 
     except ApplyError as err:
-        return {"msg": "Error", "code": err.args[1] }, 400
+        return {"msg": "Error", "code": err.args[1]}, 400
 
-    ret = { "msg": "ok" }
-
+    ret = {"msg": "ok"}
 
     # -------------------------------------
     # CALCULATE CONFLICTS
     # -------------------------------------
-    if 'disable' in apply_data:
-
-        query = Book.select(Book.sid, Book.fromts, Book.tots, Users.login, Users.name) \
-                    .join(Users, on=(Book.login == Users.login)) \
-                    .where((Book.fromts < ts['toTS']) & (Book.tots > ts['fromTS'])) \
-                    .where(Book.sid.in_(apply_data['disable']))
+    if "disable" in apply_data:
+        query = (
+            Book.select(Book.sid, Book.fromts, Book.tots, Users.login, Users.name)
+            .join(Users, on=(Book.login == Users.login))
+            .where((Book.fromts < ts["toTS"]) & (Book.tots > ts["fromTS"]))
+            .where(Book.sid.in_(apply_data["disable"]))
+        )
 
         conflicts_in_disable = [
             {
-                "sid": row['sid'],
-                "fromTS": row['fromts'],
-                "toTS": row['tots'],
-                "login": row['login'],
-                "username": row['name']
-            } for row in query
+                "sid": row["sid"],
+                "fromTS": row["fromts"],
+                "toTS": row["tots"],
+                "login": row["login"],
+                "username": row["name"],
+            }
+            for row in query
         ]
 
         if conflicts_in_disable:
             ret["conflicts_in_disable"] = conflicts_in_disable
 
-    if 'assign' in apply_data and len(apply_data['assign']['logins']) > 0:
-
-        query = Book.select(Book.sid, Book.fromts, Book.tots, Users.login, Users.name) \
-                    .join(Users, on=(Book.login == Users.login)) \
-                    .where((Book.fromts < ts['toTS']) & (Book.tots > ts['fromTS'])) \
-                    .where(Book.sid == apply_data['assign']['sid']) \
-                    .where(Users.login.not_in(apply_data['assign']['logins']))
+    if "assign" in apply_data and len(apply_data["assign"]["logins"]) > 0:
+        query = (
+            Book.select(Book.sid, Book.fromts, Book.tots, Users.login, Users.name)
+            .join(Users, on=(Book.login == Users.login))
+            .where((Book.fromts < ts["toTS"]) & (Book.tots > ts["fromTS"]))
+            .where(Book.sid == apply_data["assign"]["sid"])
+            .where(Users.login.not_in(apply_data["assign"]["logins"]))
+        )
 
         conflicts_in_assign = [
-            {"sid": row['sid'],
-                "fromTS": row['fromts'],
-                "toTS": row['tots'],
-                "login": row['login'],
-                "username": row['name']} for row in query]
+            {
+                "sid": row["sid"],
+                "fromTS": row["fromts"],
+                "toTS": row["tots"],
+                "login": row["login"],
+                "username": row["name"],
+            }
+            for row in query
+        ]
 
         if conflicts_in_assign:
             ret["conflicts_in_assign"] = conflicts_in_assign
@@ -439,7 +439,7 @@ def apply():
     return ret, 200
 
 
-#Format
+# Format
 # {
 #   data: {
 #         login1: { name: "User 1", role: 1 }
@@ -452,25 +452,24 @@ def apply():
 # }
 @bp.route("getUsers/<zid>")
 def getUsers(zid):
-
-    zoneUsers = UserToZoneRoles.select(Users.login, Users.name, UserToZoneRoles.zone_role) \
-                               .join(Users, on=(UserToZoneRoles.login == Users.login) ) \
-                               .where(UserToZoneRoles.zid == zid)
+    zoneUsers = (
+        UserToZoneRoles.select(Users.login, Users.name, UserToZoneRoles.zone_role)
+        .join(Users, on=(UserToZoneRoles.login == Users.login))
+        .where(UserToZoneRoles.zid == zid)
+    )
 
     res = {}
 
     for u in zoneUsers.iterator():
+        if u["login"] == flask.g.login:
+            if u["zone_role"] > ZONE_ROLE_ADMIN:
+                return {"msg": "Forbidden", "code": 120}, 403
 
-        if u['login'] == flask.g.login:
-            if u['zone_role'] > ZONE_ROLE_ADMIN:
-                return {"msg": "Forbidden", "code": 120 }, 403
-
-        res[ u['login'] ] = u['name']
+        res[u["login"]] = u["name"]
 
     if flask.g.login not in res:
-        return {"msg": "Forbidden", "code": 121 }, 403
+        return {"msg": "Forbidden", "code": 121}, 403
 
     return flask.current_app.response_class(
-        response=orjson.dumps(res),
-        status=200,
-        mimetype='application/json')
+        response=orjson.dumps(res), status=200, mimetype="application/json"
+    )

--- a/warp/xhr/zones.py
+++ b/warp/xhr/zones.py
@@ -1,38 +1,40 @@
 import os
 
 import flask
-from peewee import JOIN, fn, EXCLUDED
-from jsonschema import validate, ValidationError
 import orjson
+from jsonschema import ValidationError, validate
+from peewee import EXCLUDED, JOIN, fn
 
+from warp import blob_storage, utils
 from warp.db import *
-from warp import utils
 from warp.utils_tabulator import *
-from warp import blob_storage
 
-bp = flask.Blueprint('zones', __name__, url_prefix='zones')
+bp = flask.Blueprint("zones", __name__, url_prefix="zones")
 
-@bp.route("list", endpoint='list', methods=["POST"])
-@utils.validateJSONInput(tabulatorSchema,isAdmin=True)
-def listW():              #list is a built-in type
 
+@bp.route("list", endpoint="list", methods=["POST"])
+@utils.validateJSONInput(tabulatorSchema, isAdmin=True)
+def listW():  # list is a built-in type
     requestData = flask.request.get_json()
 
-    countQuery = UserToZoneRoles.select( \
-            UserToZoneRoles.zid, \
-            COUNT_STAR.filter(UserToZoneRoles.zone_role == ZONE_ROLE_ADMIN).alias("admins"), \
-            COUNT_STAR.filter(UserToZoneRoles.zone_role == ZONE_ROLE_USER).alias("users"), \
-            COUNT_STAR.filter(UserToZoneRoles.zone_role == ZONE_ROLE_VIEWER).alias("viewers")) \
-        .group_by(UserToZoneRoles.zid)
-    query = Zone.select(Zone.id, Zone.name, Zone.zone_group,
-                        fn.COALESCE(countQuery.c.admins,0).alias('admins'),
-                        fn.COALESCE(countQuery.c.users,0).alias('users'),
-                        fn.COALESCE(countQuery.c.viewers,0).alias('viewers')) \
-                .join(countQuery, join_type=JOIN.LEFT_OUTER, on=(Zone.id == countQuery.c.zid))
+    countQuery = UserToZoneRoles.select(
+        UserToZoneRoles.zid,
+        COUNT_STAR.filter(UserToZoneRoles.zone_role == ZONE_ROLE_ADMIN).alias("admins"),
+        COUNT_STAR.filter(UserToZoneRoles.zone_role == ZONE_ROLE_USER).alias("users"),
+        COUNT_STAR.filter(UserToZoneRoles.zone_role == ZONE_ROLE_VIEWER).alias("viewers"),
+    ).group_by(UserToZoneRoles.zid)
+    query = Zone.select(
+        Zone.id,
+        Zone.name,
+        Zone.zone_group,
+        fn.COALESCE(countQuery.c.admins, 0).alias("admins"),
+        fn.COALESCE(countQuery.c.users, 0).alias("users"),
+        fn.COALESCE(countQuery.c.viewers, 0).alias("viewers"),
+    ).join(countQuery, join_type=JOIN.LEFT_OUTER, on=(Zone.id == countQuery.c.zid))
 
-    (query, lastPage) = applyTabulatorToQuery(query,requestData)
+    (query, lastPage) = applyTabulatorToQuery(query, requestData)
 
-    res = { "data": [ *query.iterator() ] }
+    res = {"data": [*query.iterator()]}
 
     if lastPage is not None:
         res["last_page"] = lastPage
@@ -40,57 +42,55 @@ def listW():              #list is a built-in type
     return res, 200
 
 
-
 deleteSchema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "id" : {"type" : "integer"},
+        "id": {"type": "integer"},
     },
-    "required": [ "id" ]
+    "required": ["id"],
 }
+
 
 # Format:
 # { id: id }
 @bp.route("delete", methods=["POST"])
-@utils.validateJSONInput(deleteSchema,isAdmin=True)
+@utils.validateJSONInput(deleteSchema, isAdmin=True)
 def delete():
-
     jsonData = flask.request.get_json()
-    id = jsonData['id']
+    id = jsonData["id"]
 
     try:
         with DB.atomic():
-
-            blob_storage.deleteBlob(
-                blobIdQuery = Zone.select(Zone.iid).where(Zone.id == id) )
+            blob_storage.deleteBlob(blobIdQuery=Zone.select(Zone.iid).where(Zone.id == id))
 
             Zone.delete().where(Zone.id == id).execute()
 
     except IntegrityError:
-        return {"msg": "Error", "code":  220}, 400
+        return {"msg": "Error", "code": 220}, 400
 
-    return {"msg": "ok" }, 200
+    return {"msg": "ok"}, 200
+
 
 addOrEditSchema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
-        "id" : {"type" : "integer"},
-        "name" : {"type" : "string"},
-        "zone_group" : {"type" : "integer"},
+        "id": {"type": "integer"},
+        "name": {"type": "string"},
+        "zone_group": {"type": "integer"},
     },
-    "required": ["name", "zone_group"]
+    "required": ["name", "zone_group"],
 }
+
 
 # Format:
 # { id: 1, (optional, if missing a new group will be created)
 #   name: "name",
 #   zone_group: 1
 @bp.route("addoredit", methods=["POST"])
-@utils.validateJSONInput(addOrEditSchema,isAdmin=True)
+@utils.validateJSONInput(addOrEditSchema, isAdmin=True)
 def addOrEdit():
-
     jsonData = flask.request.get_json()
 
     class ApplyError(Exception):
@@ -98,56 +98,63 @@ def addOrEdit():
 
     try:
         with DB.atomic():
-
             updColumns = {
-                Zone.name: jsonData['name'],
-                Zone.zone_group: jsonData['zone_group'],
+                Zone.name: jsonData["name"],
+                Zone.zone_group: jsonData["zone_group"],
             }
 
-            if 'id' in jsonData:
-
-                rowCount = Zone.update(updColumns).where(Zone.id == jsonData['id']).execute()
+            if "id" in jsonData:
+                rowCount = Zone.update(updColumns).where(Zone.id == jsonData["id"]).execute()
                 if rowCount != 1:
                     raise ApplyError("Wrong number of affected rows", 221)
 
             else:
-
                 Zone.insert(updColumns).execute()
 
-
     except IntegrityError as err:
-        return {"msg": "Error", "code": 222 }, 400
+        return {"msg": "Error", "code": 222}, 400
     except ApplyError as err:
-        return {"msg": "Error", "code": err.args[1] }, 400
+        return {"msg": "Error", "code": err.args[1]}, 400
 
-    return {"msg": "ok" }, 200
+    return {"msg": "ok"}, 200
 
-membersSchema = addToTabulatorSchema({
-    "properties": {
-        "zid": {"type": "integer"},
-    },
-    "required": ["zid"]
-})
+
+membersSchema = addToTabulatorSchema(
+    {
+        "properties": {
+            "zid": {"type": "integer"},
+        },
+        "required": ["zid"],
+    }
+)
+
 
 @bp.route("members", methods=["POST"])
-@utils.validateJSONInput(membersSchema,isAdmin=True)
+@utils.validateJSONInput(membersSchema, isAdmin=True)
 def members():
-
     requestData = flask.request.get_json()
-    zid = requestData['zid']
+    zid = requestData["zid"]
 
-    query = ZoneAssign.select(Users.login, Users.name, ZoneAssign.zone_role, (Users.account_type >= ACCOUNT_TYPE_GROUP).alias("isGroup") ) \
-                  .join(Users, on=(ZoneAssign.login == Users.login)) \
-                  .where(ZoneAssign.zid == zid)
+    query = (
+        ZoneAssign.select(
+            Users.login,
+            Users.name,
+            ZoneAssign.zone_role,
+            (Users.account_type >= ACCOUNT_TYPE_GROUP).alias("isGroup"),
+        )
+        .join(Users, on=(ZoneAssign.login == Users.login))
+        .where(ZoneAssign.zid == zid)
+    )
 
-    (query, lastPage) = applyTabulatorToQuery(query,requestData)
+    (query, lastPage) = applyTabulatorToQuery(query, requestData)
 
-    res = { "data": [ *query.iterator() ] }
+    res = {"data": [*query.iterator()]}
 
     if lastPage is not None:
         res["last_page"] = lastPage
 
     return res
+
 
 assignSchema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -160,25 +167,25 @@ assignSchema = {
             "items": {
                 "type": "object",
                 "properties": {
-                    "login" : {"type" : "string"},
-                    "role" : {"enum" : [ZONE_ROLE_ADMIN,ZONE_ROLE_USER,ZONE_ROLE_VIEWER]}
+                    "login": {"type": "string"},
+                    "role": {"enum": [ZONE_ROLE_ADMIN, ZONE_ROLE_USER, ZONE_ROLE_VIEWER]},
                 },
-                "required": [ "login", "role"],
+                "required": ["login", "role"],
             },
         },
         "remove": {
             "type": "array",
             "minItems": 1,
-            "items": { "type": "string" },
+            "items": {"type": "string"},
         },
     },
-    "required": ['zid']
+    "required": ["zid"],
 }
 
-@bp.route("assign", methods=["POST"])
-@utils.validateJSONInput(assignSchema,isAdmin=True)
-def assign():
 
+@bp.route("assign", methods=["POST"])
+@utils.validateJSONInput(assignSchema, isAdmin=True)
+def assign():
     jsonData = flask.request.get_json()
 
     class ApplyError(Exception):
@@ -186,44 +193,44 @@ def assign():
 
     try:
         with DB.atomic():
+            zid = jsonData["zid"]
 
-            zid = jsonData['zid']
-
-            if 'change' in jsonData:
-
+            if "change" in jsonData:
                 data = [
-                    {
-                        "zid": zid,
-                        "login": i['login'],
-                        "zone_role": i['role']
-                    } for i in jsonData['change'] ]
+                    {"zid": zid, "login": i["login"], "zone_role": i["role"]}
+                    for i in jsonData["change"]
+                ]
 
-                rowCount = ZoneAssign.insert(data) \
-                                .on_conflict(
-                                    conflict_target=[ZoneAssign.zid,ZoneAssign.login],
-                                    update={ZoneAssign.zone_role: EXCLUDED.zone_role} ) \
-                                .as_rowcount() \
-                                .execute()
+                rowCount = (
+                    ZoneAssign.insert(data)
+                    .on_conflict(
+                        conflict_target=[ZoneAssign.zid, ZoneAssign.login],
+                        update={ZoneAssign.zone_role: EXCLUDED.zone_role},
+                    )
+                    .as_rowcount()
+                    .execute()
+                )
 
-                if rowCount != len(jsonData['change']):
+                if rowCount != len(jsonData["change"]):
                     raise ApplyError("Wrong number of affected rows", 223)
 
-            if 'remove' in jsonData:
+            if "remove" in jsonData:
+                rowCount = (
+                    ZoneAssign.delete()
+                    .where((ZoneAssign.zid == zid) & (ZoneAssign.login.in_(jsonData["remove"])))
+                    .execute()
+                )
 
-                rowCount = ZoneAssign.delete() \
-                                    .where( (ZoneAssign.zid == zid) & (ZoneAssign.login.in_(jsonData['remove'])) ) \
-                                    .execute()
-
-                if rowCount != len(jsonData['remove']):
+                if rowCount != len(jsonData["remove"]):
                     raise ApplyError("Wrong number of affected rows", 224)
 
-
     except IntegrityError as err:
-        return {"msg": "Error", "code": 225 }, 400
+        return {"msg": "Error", "code": 225}, 400
     except ApplyError as err:
-        return {"msg": "Error", "code": err.args[1] }, 400
+        return {"msg": "Error", "code": err.args[1]}, 400
 
-    return {"msg": "ok" }, 200
+    return {"msg": "ok"}, 200
+
 
 # Format
 #
@@ -242,22 +249,23 @@ def assign():
 # }
 @bp.route("modify", methods=["POST"])
 def modify():
-
     if not flask.g.isAdmin:
-        return {"msg": "Forbidden", "code": 230 }, 403
+        return {"msg": "Forbidden", "code": 230}, 403
 
-    imageFile = flask.request.files.get('image', None)
+    imageFile = flask.request.files.get("image", None)
     if imageFile is not None:
-
         mimeType = None
         allowedMagics = [
             # JPEG
-            (b'\xFF\xD8\xFF\xDB', "image/jpeg"),
-            (b'\xFF\xD8\xFF\xE0\x00\x10\x4A\x46\x49\x46\x00\x01', "image/jpeg"),
-            (b'\xFF\xD8\xFF\xEE', "image/jpeg"),
-            (b'\xFF\xD8\xFF\xE1', "image/jpeg"), # let's ignore the following part \x??\x??\x45\x78\x69\x66\x00\x00'
+            (b"\xFF\xD8\xFF\xDB", "image/jpeg"),
+            (b"\xFF\xD8\xFF\xE0\x00\x10\x4A\x46\x49\x46\x00\x01", "image/jpeg"),
+            (b"\xFF\xD8\xFF\xEE", "image/jpeg"),
+            (
+                b"\xFF\xD8\xFF\xE1",
+                "image/jpeg",
+            ),  # let's ignore the following part \x??\x??\x45\x78\x69\x66\x00\x00'
             # PNG
-            (b'\x89\x50\x4E\x47\x0D\x0A\x1A\x0A', "image/png"),
+            (b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A", "image/png"),
         ]
 
         magic = imageFile.stream.read(12)
@@ -266,15 +274,15 @@ def modify():
                 mimeType = i[1]
                 break
         else:
-            return {"msg": "Wrong file format", "code": 231 }, 400
+            return {"msg": "Wrong file format", "code": 231}, 400
 
-        imageFile.stream.seek(0,os.SEEK_END)
-        if imageFile.stream.tell() > flask.current_app.config['MAX_MAP_SIZE']:
-            return {"msg": "Image too big", "code": 232 }, 400
+        imageFile.stream.seek(0, os.SEEK_END)
+        if imageFile.stream.tell() > flask.current_app.config["MAX_MAP_SIZE"]:
+            return {"msg": "Image too big", "code": 232}, 400
 
-        imageFile.stream.seek(0,os.SEEK_SET)
+        imageFile.stream.seek(0, os.SEEK_SET)
 
-    jsonData = flask.request.form.get('json', None)
+    jsonData = flask.request.form.get("json", None)
 
     jsonSchema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -286,48 +294,43 @@ def modify():
                 "items": {
                     "type": "object",
                     "properties": {
-                        "sid" : {"type" : "integer"},
-                        "name" : {"type" : "string"},
-                        "x" : {"type" : "integer"},
-                        "y" : {"type" : "integer"},
+                        "sid": {"type": "integer"},
+                        "name": {"type": "string"},
+                        "x": {"type": "integer"},
+                        "y": {"type": "integer"},
                     },
                     "anyOf": [
-                        {"required": ["sid"] },
-                        {"required": ["name","x","y"] },
+                        {"required": ["sid"]},
+                        {"required": ["name", "x", "y"]},
                     ],
                 },
             },
             "remove": {
                 "type": "array",
-                "items": { "type": "integer" },
+                "items": {"type": "integer"},
             },
         },
-        "required": ['zid'],
-        "additionalProperties": False
+        "required": ["zid"],
+        "additionalProperties": False,
     }
 
     try:
         jsonData = orjson.loads(jsonData)
-        validate(jsonData,jsonSchema)
+        validate(jsonData, jsonSchema)
     except orjson.JSONDecodeError:
-        return {"msg": "Error in paring JSON", "code": 233 }, 400
+        return {"msg": "Error in paring JSON", "code": 233}, 400
     except ValidationError as err:
-        return {"msg": "Data error", "code": 234 }, 400
+        return {"msg": "Data error", "code": 234}, 400
 
     class ApplyError(Exception):
         pass
 
-    zid = jsonData['zid']
+    zid = jsonData["zid"]
 
     try:
-
         with DB.atomic():
-
             if imageFile is not None:
-
-                blobId = Zone.select(Zone.iid) \
-                            .where(Zone.id == zid) \
-                            .scalar(as_tuple = True)
+                blobId = Zone.select(Zone.iid).where(Zone.id == zid).scalar(as_tuple=True)
 
                 if blobId is None:
                     raise ApplyError("Wrong zid", 235)
@@ -339,42 +342,34 @@ def modify():
                     raise ApplyError("Blob not created", 236)
 
                 if blobId != newBlobId:
-                    Zone.update({Zone.iid: newBlobId}) \
-                        .where(Zone.id == zid) \
-                        .execute()
+                    Zone.update({Zone.iid: newBlobId}).where(Zone.id == zid).execute()
 
-            if 'remove' in jsonData:
+            if "remove" in jsonData:
+                rowCount = (
+                    Seat.delete()
+                    .where((Seat.id.in_(jsonData["remove"])) & (Seat.zid == zid))
+                    .execute()
+                )
 
-                rowCount = Seat.delete() \
-                                .where( (Seat.id.in_(jsonData['remove'])) & (Seat.zid == zid) ) \
-                                .execute()
-
-                if rowCount != len(jsonData['remove']):
+                if rowCount != len(jsonData["remove"]):
                     raise ApplyError("Wrong number of affected rows", 237)
 
-            if 'addOrUpdate' in jsonData:
-
-                columnsMap = {
-                    'sid': Seat.id,
-                    'name': Seat.name,
-                    'x': Seat.x,
-                    'y': Seat.y
-                }
+            if "addOrUpdate" in jsonData:
+                columnsMap = {"sid": Seat.id, "name": Seat.name, "x": Seat.x, "y": Seat.y}
 
                 dataInsert = []
                 totalCount = 0
-                for i in jsonData['addOrUpdate']:
-
+                for i in jsonData["addOrUpdate"]:
                     entry = {}
-                    for column,value in i.items():
+                    for column, value in i.items():
                         if column in columnsMap:
                             entry[columnsMap[column]] = value
 
                     if Seat.id in entry:
                         sid = entry.pop(Seat.id)
-                        rowCount = Seat.update(entry) \
-                                        .where( (Seat.id == sid) & (Seat.zid == zid) )\
-                                        .execute()
+                        rowCount = (
+                            Seat.update(entry).where((Seat.id == sid) & (Seat.zid == zid)).execute()
+                        )
                         totalCount += rowCount
                     else:
                         entry[Seat.zid] = zid
@@ -384,33 +379,24 @@ def modify():
                     rowCount = Seat.insert(dataInsert).as_rowcount().execute()
                     totalCount += rowCount
 
-                if totalCount != len(jsonData['addOrUpdate']):
+                if totalCount != len(jsonData["addOrUpdate"]):
                     raise ApplyError("Wrong number of affected rows", 238)
 
     except ApplyError as err:
-        return {"msg": "Error", "code": err.args[1] }, 400
+        return {"msg": "Error", "code": err.args[1]}, 400
 
     return {"msg": "ok"}, 200
 
 
 @bp.route("getSeats/<int:zid>")
 def getSeats(zid):
-
     if not flask.g.isAdmin:
-        return {"msg": "Forbidden", "code": 250 }, 403
+        return {"msg": "Forbidden", "code": 250}, 403
 
-    query = Seat.select(Seat.id, Seat.name, Seat.x, Seat.y) \
-                .where(Seat.zid == zid)
+    query = Seat.select(Seat.id, Seat.name, Seat.x, Seat.y).where(Seat.zid == zid)
 
-    res = {
-        str(i['id']): {
-            "name": i['name'],
-            "x": i['x'],
-            "y": i['y']
-            } for i in query.iterator()
-    }
+    res = {str(i["id"]): {"name": i["name"], "x": i["x"], "y": i["y"]} for i in query.iterator()}
 
     return flask.current_app.response_class(
-        response=orjson.dumps(res),
-        status=200,
-        mimetype='application/json')
+        response=orjson.dumps(res), status=200, mimetype="application/json"
+    )

--- a/warp/xhr/zones.py
+++ b/warp/xhr/zones.py
@@ -5,9 +5,22 @@ import orjson
 from jsonschema import ValidationError, validate
 from peewee import EXCLUDED, JOIN, fn
 
-from warp import blob_storage, utils
-from warp.db import *
-from warp.utils_tabulator import *
+from .. import blob_storage, utils
+from ..db import (
+    ACCOUNT_TYPE_GROUP,
+    COUNT_STAR,
+    DB,
+    ZONE_ROLE_ADMIN,
+    ZONE_ROLE_USER,
+    ZONE_ROLE_VIEWER,
+    IntegrityError,
+    Seat,
+    Users,
+    UserToZoneRoles,
+    Zone,
+    ZoneAssign,
+)
+from ..utils_tabulator import addToTabulatorSchema, applyTabulatorToQuery, tabulatorSchema
 
 bp = flask.Blueprint("zones", __name__, url_prefix="zones")
 


### PR DESCRIPTION
This pull request is associated to issue https://github.com/sebo-b/warp/issues/20

Modifications were automatically applied with the following commands.

Cleanup on import is not over, it still requires manual cleanup, but @sebo-b you can have a look. 

The line length chosen as 100 characters can be updated


% isort --version

                 _                 _
                (_) ___  ___  _ __| |_
                | |/ _/ / _ \/ '__  _/
                | |\__ \/\_\/| |  | |_
                |_|\___/\___/\_/   \_/

      isort your imports, so you don't have to.

                    VERSION 5.12.0

% black --version
black, 23.1.0 (compiled: yes)
Python (CPython) 3.10.6

isort --profile black -l 100 warp
black -l 100 warp