### PR TITLE
Fix conflicting bookings login filter

### DIFF
--- a/js/views/modules/seat.js
+++ b/js/views/modules/seat.js
@@ -158,7 +158,7 @@ WarpSeatFactory.prototype.updateLogin = function(login, seatsData) {
 
         for (let i of seat._bookingsIterator()) {
 
-            if (!i.book.login == this.login)
+            if (i.book.login != this.login)
                 continue;
 
             if (raw) {


### PR DESCRIPTION
Hi,

I found out that when selecting a time range overlapping user's existing booking and someone else's booking on a seat, the delete action deletes both bookings.

I think the cause is in `WarpSeatFactory.getMyConflictingBookings` :
 
`!i.book.login == this.login` casts `i.book.login` as boolean first then compare its opposite value to `this.login`.

`i.book.login != this.login` checks if values are different.

Another way to do it could be `!(i.book.login == this.login)`