### PR TITLE
Add config to omit some weekdays

### DIFF
--- a/warp/config.py
+++ b/warp/config.py
@@ -14,6 +14,10 @@ class DefaultSettings(object):
     # (after the current week)
     WEEKS_IN_ADVANCE = 1
 
+    # Weekdays to hide for reservation, 0 for monday to 6 for sunday
+    # Set to [5,6] to omit weekends
+    OMITTED_WEEKDAYS = []
+
     MAX_CONTENT_LENGTH = 5 * 1024 * 1024
 
     # maximum size of uploaded map file

--- a/warp/utils.py
+++ b/warp/utils.py
@@ -52,16 +52,18 @@ def getNextWeek():
     noOfSundays = 0
 
     weeksInAdvance = flask.current_app.config['WEEKS_IN_ADVANCE']
+    omittedWeekdays = flask.current_app.config['OMITTED_WEEKDAYS']
 
     while noOfSundays <= weeksInAdvance:
 
         t = gmtime(ts)
-        res.append( {
-            "timestamp": ts,
-            "date": strftime("%Y-%m-%d",t),
-            "weekdayN": strftime("%w",t),
-            "isWeekend": t.tm_wday>=5
-        })
+        if t.tm_wday not in omittedWeekdays:
+            res.append( {
+                "timestamp": ts,
+                "date": strftime("%Y-%m-%d",t),
+                "weekdayN": strftime("%w",t),
+                "isWeekend": t.tm_wday>=5
+            })
 
         ts = ts + 24*3600
 


### PR DESCRIPTION
Set `WARP_OMITTED_WEEKDAYS` to `[5,6]` to remove weekends from booking available dates.
It allows to cover a bigger date span in the same screen space and may be consistent to office days.