### PR TITLE
Add opening time config

### DIFF
--- a/js/views/zone.js
+++ b/js/views/zone.js
@@ -58,7 +58,7 @@ function initSlider() {
         step: 15*60,
         margin: 15*60,
         orientation: 'vertical',
-        range: { 'min': 0, 'max': 24*3600 }
+        range: { min: +slider.dataset.min, max: +slider.dataset.max }
     });
 
     var minDiv = document.getElementById('timeslider-min');

--- a/warp/config.py
+++ b/warp/config.py
@@ -14,6 +14,10 @@ class DefaultSettings(object):
     # (after the current week)
     WEEKS_IN_ADVANCE = 1
 
+    # opening and closing time in seconds from 00:00
+    BOOK_OPEN = 0
+    BOOK_CLOSE = 24 * 3600
+
     MAX_CONTENT_LENGTH = 5 * 1024 * 1024
 
     # maximum size of uploaded map file

--- a/warp/templates/zone.html
+++ b/warp/templates/zone.html
@@ -171,7 +171,7 @@
 
                 <div class="zone_timeslider">
                     <div id="timeslider-min" class="timeslider-hint">12:00</div>
-                    <div id="timeslider" class="timeslider"></div>
+                    <div id="timeslider" class="timeslider" data-min="{{ config['BOOK_OPEN'] }}" data-max="{{ config['BOOK_CLOSE'] }}"></div>
                     <div id="timeslider-max" class="timeslider-hint">12:00</div>
                 </div>
             </div>


### PR DESCRIPTION
Set `WARP_BOOK_OPEN` and `WARP_BOOK_CLOSE` to the number of seconds from 00:00 to set opening and closing times for bookings to prevent bookings over closed office time.

Example :
`WARP_BOOK_OPEN` to 25200
`WARP_BOOK_CLOSE` to 68400
The time slider starts at 07:00 and finishes at 19:00