### PR TITLE
small seat previews and additional strategies for preselected dates

### DIFF
--- a/js/base/style.css
+++ b/js/base/style.css
@@ -196,10 +196,32 @@ NAV {
 }
 
 .zonemap_help {
-    position: fixed;
-    right: 0px;
     color: #9e9e9e;
     cursor: pointer;
+    margin-left: auto;
+}
+
+.zonemap_menu_left_bottom {
+    position: fixed;
+    right: 0px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    overflow: auto;
+    padding: 10px;
+    z-index: 1000;
+}
+
+.zonemap_menu_right_bottom {
+    position: fixed;
+    right: 0px;
+    bottom: 0px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    overflow: auto;
+    padding: 10px;
+    z-index: 1000;
 }
 
 .zone_action_btn {

--- a/js/views/bookings.js
+++ b/js/views/bookings.js
@@ -72,8 +72,8 @@ document.addEventListener("DOMContentLoaded", function(e) {
             showClearBtn: true,
             format: "yyyy-mm-dd",
             onClose: function() {
-                let fromTS = fromDatePicker.value? Math.round(Date.parse(fromDatePicker.value)/1000): null
-                let toTS = toDatePicker.value? Math.round(Date.parse(toDatePicker.value)/1000)+24*3600-1: null
+                let fromTS = fromDatePicker.value? Math.round(Date.parse(fromDatePicker.value)/1000): null;
+                let toTS = toDatePicker.value? Math.round(Date.parse(toDatePicker.value)/1000)+24*3600-1: null;
                 if (fromTS !== null && toTS !== null) {
                     success({
                         fromTS: fromDatePicker.value? Math.round(Date.parse(fromDatePicker.value)/1000): null,

--- a/js/views/bookings.js
+++ b/js/views/bookings.js
@@ -72,10 +72,16 @@ document.addEventListener("DOMContentLoaded", function(e) {
             showClearBtn: true,
             format: "yyyy-mm-dd",
             onClose: function() {
-                success({
-                    fromTS: fromDatePicker.value? Math.round(Date.parse(fromDatePicker.value)/1000): null,
-                    toTS: toDatePicker.value? Math.round(Date.parse(toDatePicker.value)/1000)+24*3600-1: null
-                });
+                let fromTS = fromDatePicker.value? Math.round(Date.parse(fromDatePicker.value)/1000): null
+                let toTS = toDatePicker.value? Math.round(Date.parse(toDatePicker.value)/1000)+24*3600-1: null
+                if (fromTS !== null && toTS !== null) {
+                    success({
+                        fromTS: fromDatePicker.value? Math.round(Date.parse(fromDatePicker.value)/1000): null,
+                        toTS: toDatePicker.value? Math.round(Date.parse(toDatePicker.value)/1000)+24*3600-1: null
+                    });
+                } else {
+                    cancel();
+                };
              }
         };
 
@@ -189,10 +195,14 @@ document.addEventListener("DOMContentLoaded", function(e) {
     }
     else {
         columns.push(
-            {title:TR("Time"), field: "fromTS", width: 275,
-                formatter:mergedTsFormatter,
-                headerFilter:mergedDateFilterEditor,
-                headerFilterFunc:function(){} },
+            {
+                title: TR("Time"), 
+                field: "fromTS", 
+                width: 275,
+                formatter: mergedTsFormatter,
+                headerFilter: mergedDateFilterEditor,
+                headerFilterFunc: function(){} 
+            },
         );
 
         columns.splice(0,0,

--- a/js/views/zone.js
+++ b/js/views/zone.js
@@ -140,8 +140,12 @@ function initSmallPreviews(seatFactory, zoneMap) {
 
         var header = null;
         if (bookings.length) {
-            header = previewDiv.appendChild(document.createElement("span"));
-            header.appendChild(document.createTextNode(bookings[0].username));
+            header = previewDiv.appendChild(document.createElement("div"));
+            let headerSpan = header.appendChild(document.createElement("span"));
+            bookings[0].username.split(' ').forEach(function(n) {
+                headerSpan.appendChild(document.createTextNode(n));
+                headerSpan.appendChild(document.createElement('br'));
+            })
             header.className = "seat_preview_header";
         }
 
@@ -163,8 +167,12 @@ function updateAllSmallPreviews() {
             d.header = null;
         }
         if (bookings.length) {
-            d.header = d.previewDiv.appendChild(document.createElement("span"));
-            d.header.appendChild(document.createTextNode(bookings[0].username));
+            d.header = d.previewDiv.appendChild(document.createElement("div"));
+            let headerSpan = d.header.appendChild(document.createElement("span"));
+            bookings[0].username.split(' ').forEach(function(n) {
+                headerSpan.appendChild(document.createTextNode(n));
+                headerSpan.appendChild(document.createElement('br'));
+            })
             d.header.className = "seat_preview_header";
         }
     }

--- a/js/views/zone.js
+++ b/js/views/zone.js
@@ -117,10 +117,10 @@ function initPreviewDiv(seat_name, position, with_title) {
     return previewDiv;
 }
 
-const all_small_seat_previews = []
+const all_small_seat_previews = [];
 function initSmallPreviews(seatFactory, zoneMap) {
     for (const value in seatFactory.instances) {
-        var seat = seatFactory.instances[value]
+        var seat = seatFactory.instances[value];
         if (seat.otherZone) {
             continue;
         }
@@ -138,7 +138,7 @@ function initSmallPreviews(seatFactory, zoneMap) {
 
         var previewDiv = initPreviewDiv(seat_name, position, true);
 
-        var header = null
+        var header = null;
         if (bookings.length) {
             header = previewDiv.appendChild(document.createElement("span"));
             header.appendChild(document.createTextNode(bookings[0].username));
@@ -159,11 +159,11 @@ function updateAllSmallPreviews() {
     for (const d of all_small_seat_previews) {
         var bookings = d.seat.getBookings();
         if (d.header !== null) {
-            d.header.remove()
-            d.header = null
+            d.header.remove();
+            d.header = null;
         }
         if (bookings.length) {
-            d.header = d.previewDiv.appendChild(document.createElement("span"))
+            d.header = d.previewDiv.appendChild(document.createElement("span"));
             d.header.appendChild(document.createTextNode(bookings[0].username));
             d.header.className = "seat_preview_header";
         }
@@ -172,14 +172,14 @@ function updateAllSmallPreviews() {
 
 function handleSmallPreviews(seatFactory, zoneMap) {
     if (all_small_seat_previews.length !== 0) {
-        updateAllSmallPreviews()
+        updateAllSmallPreviews();
     } else {
-        initSmallPreviews(seatFactory, zoneMap)
+        initSmallPreviews(seatFactory, zoneMap);
     }
 }
 
 function initSeatPreview(seatFactory, previewCheckbox, zoneMap) {
-    let currentPreview = null
+    let currentPreview = null;
 
     seatFactory.on( 'mouseover', function() {
         var assignments = Object.values(this.getAssignments());
@@ -189,7 +189,7 @@ function initSeatPreview(seatFactory, previewCheckbox, zoneMap) {
         var bookings = this.getBookings();
 
         if (previewCheckbox.checked && !assignments.length && !bookings.length) {
-            return
+            return;
         }
 
         var parentWidth = zoneMap.clientWidth;
@@ -236,7 +236,7 @@ function initSeatPreview(seatFactory, previewCheckbox, zoneMap) {
 
         if (bookings.length) {
 
-            var header = previewDiv.appendChild(document.createElement("span"))
+            var header = previewDiv.appendChild(document.createElement("span"));
             header.appendChild(document.createTextNode(TR("Bookings:")));
             header.className = "seat_preview_header";
 
@@ -262,7 +262,7 @@ function initSeatPreview(seatFactory, previewCheckbox, zoneMap) {
         }
 
         zoneMap.appendChild(previewDiv);
-        currentPreview = previewDiv
+        currentPreview = previewDiv;
     });
 
     previewCheckbox.addEventListener("change", function() {
@@ -285,8 +285,8 @@ function initSeatPreview(seatFactory, previewCheckbox, zoneMap) {
 
     seatFactory.on( 'mouseout', function() {
         if (currentPreview !== null) {
-            currentPreview.remove()
-            currentPreview = null
+            currentPreview.remove();
+            currentPreview = null;
         }
     });
 

--- a/warp/config.py
+++ b/warp/config.py
@@ -59,6 +59,13 @@ class DefaultSettings(object):
     # MELLON_ENDPOINT
     # MELLON_DEFAULT_GROUP
 
+    # Date/Time defaults
+    PRESELECTED_DATES_STRATEGY = "tomorrow"
+    RESTORE_SELECTED_DATES = True
+    PRESELECTED_TIMES_STRATEGY = "predefined_timespan"
+    PRESELECTED_TIMES_START = 9
+    PRESELECTED_TIMES_END = 17
+
 class DevelopmentSettings(DefaultSettings):
 
     DATABASE = "postgresql://postgres:postgres_password@127.0.0.1:5432/postgres"

--- a/warp/templates/zone.html
+++ b/warp/templates/zone.html
@@ -9,6 +9,7 @@
         window.warpGlobals.URLs['seatSprite'] = "{{ url_for('static',filename='images/seat_icons.png') }}";
 
         window.warpGlobals['defaultSelectedDates'] = {{ defaultSelectedDates | tojson }};
+        window.warpGlobals['restoreSelectedDates'] = {{ restoreSelectedDates }};
 
         {% if isZoneAdmin %}
         window.warpGlobals.isZoneAdmin = true;
@@ -143,14 +144,15 @@
 
             <div class="zone_sidepanel_topcontainer">
 
-                <div class="input-field book-as_container">
-                    <input type="text" id="book-as" class="autocomplete book-as_input" autocomplete="off">
-                    <label for="book-as" class="active TR">Book as</label>
-                </div>
+                    <div class="input-field book-as_container">
+                        <input type="text" id="book-as" class="autocomplete book-as_input" autocomplete="off">
+                        <label for="book-as" class="active TR">Book as</label>
+                    </div>
 
-                <div class="zone_sidepanel_close sidenav-close" data-target="zone_sidepanel">
-                    <i class="material-icons">close</i>
-                </div>
+                    <div class="zone_sidepanel_close sidenav-close" data-target="zone_sidepanel">
+                        <i class="material-icons">close</i>
+                    </div>
+
             </div>
 
             <div class="zone_datetime_container">
@@ -178,15 +180,26 @@
 
         </div>
 
-
-        <div class="zone_map" id="zonemap">
+        <div class="zonemap_menu_left_bottom">
             <div class="zonemap_help">
                 <img src="{{ url_for('static', filename='images/help_icon.png') }}">
             </div>
+        </div>
+        <div class="zonemap_menu_right_bottom">
+            <div class="zonemap_toggle_preview">
+                <label>
+                    <input class="filled-in preview_checkbox" type="checkbox" id="preview-checkbox"/>
+                    <span>Seat previews</span>
+                </label>
+            </div>
+        </div>
+
+        <div class="zone_map" id="zonemap">
             <div class="zonemap_datetime_trigger sidenav-trigger" data-target="zone_sidepanel">
                 <img src="{{ url_for('static', filename='images/schedule_icon_side.png') }}">
             </div>
             <img src="{{ url_for('view.zoneImage', zid=zid) }}">
+            <div class="zonemap-seats" id="zonemap-seats"></div>
         </div>
 
 {% endblock %}


### PR DESCRIPTION
Hi, 
I added a checkbox that enables small previews in the zone. It shows the number of the seat and the username of the first Booking of the currently set timespan. When hovering over the seat, it still shows the bookings and assignments, but without the header.

The thoughts behind this feature is to have a possibility to quickly search on the map who is sitting where, without having to hover over every single seat.

![grafik](https://github.com/sebo-b/warp/assets/73887906/40f35623-07ef-472a-bc85-b3cac5554f63)

Also, I added some strategies for the preselected dates that can be set via environment variables. You can set which day is preselected (today or tomorrow) and also if the current time of day should be selected as start or a predefined timespan. To make this work, there is also a toggle to turn off the restoration of the selected dates from the session storage.

And there was a bug in the Bookings Tab, there if you did not select both start and end dates, there would flash an error. It now checks if both (fromTS and toTS) values are set.

If you want to, I can also split it to seperate PRs.

*edit: added screenshot