### PR TITLE
feat(zone): add optional seat name and booking preview labels on zone map

### DIFF
--- a/js/base/base.js
+++ b/js/base/base.js
@@ -62,6 +62,8 @@ function initPrefs() {
   var sliderEl = document.getElementById('pref_timeslider');
   var minDiv = document.getElementById('pref_timeslider-min');
   var maxDiv = document.getElementById('pref_timeslider-max');
+  var showSeatNamesEl = document.getElementById('pref_zone_show_seat_names');
+  var showBookingPreviewEl = document.getElementById('pref_zone_show_booking_preview');
 
   if (!prefModalEl || !zoneSelectEl || !daySelectEl || !saveBtn || !sliderEl)
     return;
@@ -77,6 +79,8 @@ function initPrefs() {
     M.FormSelect.init(zoneSelectEl);
     M.FormSelect.init(daySelectEl);
     if (slider) slider.set(time);
+    if (showSeatNamesEl) showSeatNamesEl.checked = loadedPrefs ? loadedPrefs.zone_show_seat_names : false;
+    if (showBookingPreviewEl) showBookingPreviewEl.checked = loadedPrefs ? loadedPrefs.zone_show_booking_preview : false;
   }
 
   function ensureSlider() {
@@ -127,7 +131,9 @@ function initPrefs() {
     var payload = {
       default_zone: zoneSelectEl.value || undefined,
       default_day: daySelectEl.value,
-      default_time: slider.get(true).map(function(v) { return Math.round(v); })
+      default_time: slider.get(true).map(function(v) { return Math.round(v); }),
+      zone_show_seat_names: showSeatNamesEl ? showSeatNamesEl.checked : false,
+      zone_show_booking_preview: showBookingPreviewEl ? showBookingPreviewEl.checked : false
     };
     if (extraPayload) Object.assign(payload, extraPayload);
 
@@ -143,6 +149,14 @@ function initPrefs() {
     .then(function(prefs) {
       loadedPrefs = prefs;
       applyPrefsToUI();
+      window.warpGlobals = window.warpGlobals || {};
+      window.warpGlobals['zonePreviewPrefs'] = {
+        show_seat_names: prefs.zone_show_seat_names,
+        show_booking_preview: prefs.zone_show_booking_preview
+      };
+      document.dispatchEvent(new CustomEvent('warp:prefsSaved', {
+        detail: { zonePreviewPrefs: window.warpGlobals['zonePreviewPrefs'] }
+      }));
       if (callback) callback(null, prefs);
     })
     .catch(function(err) {

--- a/js/base/style.css
+++ b/js/base/style.css
@@ -352,7 +352,7 @@ NAV {
     position: absolute;
     border: 2px solid #3949ab;
     background-color: white;
-    z-index: 1;
+    z-index: 3;
     font-size: 10px;
     width: fit-content;
     width: -moz-fit-content;
@@ -379,6 +379,50 @@ NAV {
     padding: 0px 4px;
     text-align: left;
     vertical-align: middle;
+}
+
+.zonemap-labels {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.seat_label {
+    position: absolute;
+    border: 2px solid #3949ab;
+    background-color: white;
+    font-size: 10px;
+    pointer-events: none;
+    max-width: 80px;
+    transform: translateX(-50%);
+    text-align: center;
+}
+
+.seat_label_hidden {
+    display: none;
+}
+
+.seat_label_title {
+    background-color: #3949ab;
+    color: white;
+    padding: 0px 4px;
+    line-height: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.seat_label_content {
+    padding: 1px 4px;
+}
+
+.seat_label_booking {
+    color: #616161;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .assigned_seat_list {

--- a/js/views/bookings.js
+++ b/js/views/bookings.js
@@ -73,8 +73,8 @@ document.addEventListener("DOMContentLoaded", function(e) {
             format: "yyyy-mm-dd",
             onClose: function() {
                 success({
-                    fromTS: fromDatePicker.value? Math.round(Date.parse(fromDatePicker.value)/1000): null,
-                    toTS: toDatePicker.value? Math.round(Date.parse(toDatePicker.value)/1000)+24*3600-1: null
+                    fromTS: fromDatePicker.value ? Math.round(Date.parse(fromDatePicker.value)/1000) : null,
+                    toTS: toDatePicker.value ? Math.round(Date.parse(toDatePicker.value)/1000)+24*3600-1 : null
                 });
              }
         };

--- a/js/views/modules/seat.js
+++ b/js/views/modules/seat.js
@@ -66,10 +66,14 @@ function WarpSeatFactory(spriteURL,rootDivId,login) {
     this.selectedDates = [];
 
     this.instances = {};
+    // click/mouseover/mouseout listeners are invoked with `this === WarpSeat instance` (via handleEvent).
+    // setSeatsData/updateAllStates listeners are factory-level and invoked with `this === factory`.
     this.listeners = {
         click: new Set(),
         mouseover: new Set(),
-        mouseout: new Set()
+        mouseout: new Set(),
+        setSeatsData: new Set(),
+        updateAllStates: new Set()
     };
 
     this.myConflictingBookings = new Set();
@@ -101,6 +105,11 @@ WarpSeatFactory.prototype.getLogin = function() {
     for (var seat of Object.values(this.instances))
         seat._updateView();
 
+    // Factory-level dispatch: this === factory
+    for (var l of this.listeners['updateAllStates']) {
+        l.call(this);
+    }
+
  }
 
 // NOTE: seatsData is not cloned
@@ -123,6 +132,11 @@ WarpSeatFactory.prototype.setSeatsData = function(seatsData = {}) {
     for (var sid of oldSeatsIds) {
         this.instances[sid]._destroy();
         delete this.instances[sid];
+    }
+
+    // Factory-level dispatch: this === factory
+    for (var l of this.listeners['setSeatsData']) {
+        l.call(this);
     }
 };
 

--- a/js/views/zone.js
+++ b/js/views/zone.js
@@ -78,7 +78,6 @@ function initSeats() {
         "zonemap",
         window.warpGlobals.login);
 
-    // register WarpSeats for updates
     var updateSeatsView = function() {
         var dates = getSelectedDates();
         seatFactory.updateAllStates(dates);
@@ -94,11 +93,209 @@ function initSeats() {
     return seatFactory;
 }
 
-function initSeatPreview(seatFactory) {
+function initSeatLabels(seatFactory) {
+
+    var labelsContainer = document.getElementById("zonemap-labels");
+    if (!labelsContainer) return;
+
+    var prefs = window.warpGlobals['zonePreviewPrefs'] || {};
+    var labelData = {};
+    var labelSignatures = {};
+    var needsFullRender = true;
+    var hoveredSid = null;
+    var suppressTooltip = false;
+
+    var TITLE_HEIGHT = 14;
+    var SPRITE_CENTER_X = WarpSeat.Sprites.spriteSize / 2;
+
+    function positionLabel(div, pands) {
+        div.style.left = (pands.x + SPRITE_CENTER_X) + "px";
+        div.style.top = (pands.y + WarpSeat.Sprites.spriteSize - TITLE_HEIGHT) + "px";
+    }
+
+    function computeSignature(seat, showSeatNames, showBookingPreview) {
+        var bookings = showBookingPreview ? seat.getBookings() : [];
+        var users = [];
+        var seen = new Set();
+        for (var b of bookings) {
+            if (seen.has(b.username)) continue;
+            seen.add(b.username);
+            users.push(b.username);
+        }
+        return (showSeatNames ? seat.getName() : '') + '\x00' + users.join('\x01');
+    }
+
+    function buildContentDiv(seat, showSeatNames, showBookingPreview) {
+
+        var bookings = showBookingPreview ? seat.getBookings() : [];
+
+        if (!showSeatNames && !bookings.length) return null;
+
+        var div = document.createElement("div");
+        div.className = "seat_label";
+
+        if (showSeatNames) {
+            var title = div.appendChild(document.createElement("div"));
+            title.className = "seat_label_title";
+            title.textContent = seat.getName();
+        }
+
+        if (showBookingPreview && bookings.length) {
+            var content = div.appendChild(document.createElement("div"));
+            content.className = "seat_label_content";
+
+            var seen = new Set();
+            for (var b of bookings) {
+                if (seen.has(b.username)) continue;
+                seen.add(b.username);
+                var row = content.appendChild(document.createElement("div"));
+                row.className = "seat_label_booking";
+                row.textContent = b.username;
+            }
+        }
+
+        return div;
+    }
+
+    function renderLabels() {
+
+        for (var sid in labelData) {
+            if (labelData[sid]) labelData[sid].remove();
+        }
+        labelData = {};
+        labelSignatures = {};
+
+        var showSeatNames = prefs.show_seat_names;
+        var showBookingPreview = prefs.show_booking_preview;
+
+        if (!showSeatNames && !showBookingPreview) {
+            needsFullRender = false;
+            return;
+        }
+
+        for (var sid in seatFactory.instances) {
+            var seat = seatFactory.instances[sid];
+            if (seat.isOtherZone()) continue;
+
+            var div = buildContentDiv(seat, showSeatNames, showBookingPreview);
+            if (!div) continue;
+
+            positionLabel(div, seat.getPositionAndSize());
+            if (sid == hoveredSid) div.classList.add("seat_label_hidden");
+
+            labelsContainer.appendChild(div);
+            labelData[sid] = div;
+            labelSignatures[sid] = computeSignature(seat, showSeatNames, showBookingPreview);
+        }
+
+        needsFullRender = false;
+    }
+
+    function updateBookingLabels() {
+
+        if (needsFullRender) {
+            renderLabels();
+            return;
+        }
+
+        var showSeatNames = prefs.show_seat_names;
+        var showBookingPreview = prefs.show_booking_preview;
+
+        for (var sid in seatFactory.instances) {
+            var seat = seatFactory.instances[sid];
+            if (seat.isOtherZone()) continue;
+
+            var bookings = showBookingPreview ? seat.getBookings() : [];
+            var existingDiv = labelData[sid];
+
+            if (!showSeatNames && !bookings.length) {
+                if (existingDiv) {
+                    existingDiv.remove();
+                    delete labelData[sid];
+                    delete labelSignatures[sid];
+                }
+                continue;
+            }
+
+            var newSig = computeSignature(seat, showSeatNames, showBookingPreview);
+            if (existingDiv && labelSignatures[sid] === newSig) continue;
+
+            var div = buildContentDiv(seat, showSeatNames, showBookingPreview);
+            if (!div) {
+                if (existingDiv) {
+                    existingDiv.remove();
+                    delete labelData[sid];
+                    delete labelSignatures[sid];
+                }
+                continue;
+            }
+
+            positionLabel(div, seat.getPositionAndSize());
+            if (sid == hoveredSid) div.classList.add("seat_label_hidden");
+
+            labelsContainer.appendChild(div);
+            labelData[sid] = div;
+            labelSignatures[sid] = newSig;
+
+            if (existingDiv) existingDiv.remove();
+        }
+    }
+
+    function refreshAllLabels() {
+        needsFullRender = true;
+        renderLabels();
+    }
+
+    seatFactory.on('setSeatsData', function() {
+        needsFullRender = true;
+        hoveredSid = null;
+        suppressTooltip = false;
+    });
+
+    seatFactory.on('updateAllStates', updateBookingLabels);
+
+    seatFactory.on('mouseover', function() {
+        var sid = String(this.getSid());
+        hoveredSid = sid;
+
+        var hasAssignments = Object.keys(this.getAssignments()).length > 0;
+        var hasBookings = this.getBookings().length > 0;
+
+        if (prefs.show_seat_names && !hasAssignments && !hasBookings) {
+            suppressTooltip = true;
+        } else {
+            suppressTooltip = false;
+            if (labelData[sid]) labelData[sid].classList.add("seat_label_hidden");
+        }
+    });
+
+    seatFactory.on('mouseout', function() {
+        if (hoveredSid && labelData[hoveredSid]) labelData[hoveredSid].classList.remove("seat_label_hidden");
+        hoveredSid = null;
+        suppressTooltip = false;
+    });
+
+    document.addEventListener('warp:prefsSaved', function(e) {
+        var newPrefs = e.detail && e.detail.zonePreviewPrefs;
+        if (!newPrefs) return;
+        prefs.show_seat_names = !!newPrefs.show_seat_names;
+        prefs.show_booking_preview = !!newPrefs.show_booking_preview;
+        refreshAllLabels();
+    });
+
+    return {
+        refreshAllLabels: refreshAllLabels,
+        shouldSuppressTooltip: function() { return suppressTooltip; }
+    };
+}
+
+function initSeatPreview(seatFactory, seatLabels) {
 
     var zoneMap = document.getElementById("zonemap");
 
     seatFactory.on( 'mouseover', function() {
+
+        if (seatLabels && seatLabels.shouldSuppressTooltip()) return;
 
         var previewDiv = document.createElement("div");
         previewDiv.className = 'seat_preview';
@@ -842,7 +1039,8 @@ document.addEventListener("DOMContentLoaded", function() {
     initShiftSelectDates();
 
     var seatFactory = initSeats();
-    initSeatPreview(seatFactory);
+    var seatLabels = initSeatLabels(seatFactory);
+    initSeatPreview(seatFactory, seatLabels);
     initActionMenu(seatFactory);
     initZoneHelp();
     initZoneSidepanel();

--- a/warp/config.py
+++ b/warp/config.py
@@ -46,6 +46,7 @@ class DefaultSettings(object):
         (6, "sql/migration_006_calendar_reminders.sql"),
         (7, "sql/migration_007_calendar_cache.sql"),
         (8, "sql/migration_008_zone_default_type.sql"),
+        (9, "sql/migration_009_zone_preview_prefs.sql"),
     ]
 
     # number of connection retries to DB on initialization

--- a/warp/db.py
+++ b/warp/db.py
@@ -19,7 +19,7 @@ ZoneAssign = Table('zone_assign',('zid','login','zone_role'))
 Book = Table('book',('id','login','sid','fromts','tots'))
 SeatAssign = Table('seat_assign',('sid','login','days_in_advance'))
 
-UserPrefs = Table('user_prefs',('login','default_zone','default_day','default_time_from','default_time_to','ical_enabled','ical_token','reminder_weekdays','reminder_ahead_days','reminder_time','reminder_release_ahead_days','reminder_zones'), primary_key='login')
+UserPrefs = Table('user_prefs',('login','default_zone','default_day','default_time_from','default_time_to','ical_enabled','ical_token','reminder_weekdays','reminder_ahead_days','reminder_time','reminder_release_ahead_days','reminder_zones','zone_show_seat_names','zone_show_booking_preview'), primary_key='login')
 
 UserToZoneRoles = Table('user_to_zone_roles',('login','zid','zone_role'))
 

--- a/warp/sql/migration_009_zone_preview_prefs.sql
+++ b/warp/sql/migration_009_zone_preview_prefs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_prefs ADD COLUMN zone_show_seat_names boolean NOT NULL DEFAULT FALSE;
+ALTER TABLE user_prefs ADD COLUMN zone_show_booking_preview boolean NOT NULL DEFAULT FALSE;

--- a/warp/sql/schema.sql
+++ b/warp/sql/schema.sql
@@ -84,6 +84,8 @@ CREATE TABLE user_prefs (
     reminder_time integer NOT NULL DEFAULT 79200,
     reminder_release_ahead_days integer NOT NULL DEFAULT 0,
     reminder_zones integer[] NOT NULL DEFAULT '{}',
+    zone_show_seat_names boolean NOT NULL DEFAULT FALSE,
+    zone_show_booking_preview boolean NOT NULL DEFAULT FALSE,
     FOREIGN KEY (login) REFERENCES users(login) ON DELETE CASCADE,
     FOREIGN KEY (default_zone) REFERENCES zone(id) ON DELETE SET NULL
 );
@@ -223,4 +225,4 @@ CREATE UNLOGGED TABLE calendar_cache (
 
 CREATE TABLE db_initialized (version INTEGER NOT NULL);
 
-INSERT INTO db_initialized(version) VALUES(8);
+INSERT INTO db_initialized(version) VALUES(9);

--- a/warp/static/i18n/de.js
+++ b/warp/static/i18n/de.js
@@ -268,4 +268,6 @@ warpGlobals.i18n.phrases = {
     'Password must be at least %{n} characters': 'Das Passwort muss mindestens %{n} Zeichen lang sein',
     'Password changed successfully': 'Passwort erfolgreich geändert',
     'Error changing password': 'Fehler beim Ändern des Passworts',
+    'Show seat names on zone map': 'Sitznamen auf Zonenkarte anzeigen',
+    'Show booking preview on zone map': 'Buchungsvorschau auf Zonenkarte anzeigen',
 };

--- a/warp/static/i18n/en.js
+++ b/warp/static/i18n/en.js
@@ -268,4 +268,6 @@ warpGlobals.i18n.phrases = {
     'Password must be at least %{n} characters': 'Password must be at least %{n} characters',
     'Password changed successfully': 'Password changed successfully',
     'Error changing password': 'Error changing password',
+    'Show seat names on zone map': 'Show seat names on zone map',
+    'Show booking preview on zone map': 'Show booking preview on zone map',
 };

--- a/warp/static/i18n/es.js
+++ b/warp/static/i18n/es.js
@@ -266,4 +266,6 @@ warpGlobals.i18n.phrases = {
     'Password must be at least %{n} characters': 'La contraseña debe tener al menos %{n} caracteres',
     'Password changed successfully': 'Contraseña cambiada correctamente',
     'Error changing password': 'Error al cambiar la contraseña',
+    'Show seat names on zone map': 'Mostrar nombres de asientos en el mapa de zonas',
+    'Show booking preview on zone map': 'Mostrar vista previa de reservas en el mapa de zonas',
 };

--- a/warp/static/i18n/fr.js
+++ b/warp/static/i18n/fr.js
@@ -266,4 +266,6 @@ warpGlobals.i18n.phrases = {
     'Password must be at least %{n} characters': 'Le mot de passe doit contenir au moins %{n} caractères',
     'Password changed successfully': 'Mot de passe modifié avec succès',
     'Error changing password': 'Erreur lors du changement de mot de passe',
+    'Show seat names on zone map': 'Afficher les noms de places sur la carte de zone',
+    'Show booking preview on zone map': "Afficher l'aperçu de réservation sur la carte de zone",
 };

--- a/warp/static/i18n/pl.js
+++ b/warp/static/i18n/pl.js
@@ -273,4 +273,6 @@ warpGlobals.i18n.phrases = {
     'Password must be at least %{n} characters': 'Hasło musi mieć co najmniej %{n} znaków',
     'Password changed successfully': 'Hasło zostało zmienione',
     'Error changing password': 'Błąd zmiany hasła',
+    'Show seat names on zone map': 'Pokaż nazwy miejsc na mapie stref',
+    'Show booking preview on zone map': 'Pokaż podgląd rezerwacji na mapie stref',
 };

--- a/warp/templates/base_logged.html
+++ b/warp/templates/base_logged.html
@@ -80,6 +80,24 @@
                     </div>
                 </div>
             </div>
+            <div class="row">
+                <div class="col s12 pref-feature-row">
+                    <span class="TR">Show seat names on zone map</span>
+                    <div class="switch"><label>
+                        <input type="checkbox" id="pref_zone_show_seat_names">
+                        <span class="lever"></span>
+                    </label></div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col s12 pref-feature-row">
+                    <span class="TR">Show booking preview on zone map</span>
+                    <div class="switch"><label>
+                        <input type="checkbox" id="pref_zone_show_booking_preview">
+                        <span class="lever"></span>
+                    </label></div>
+                </div>
+            </div>
         </div>
         <div class="modal-footer">
             <a href="#!" id="pref_save_btn" class="modal-close waves-effect waves-light btn TR">btn.Save</a>

--- a/warp/templates/zone.html
+++ b/warp/templates/zone.html
@@ -10,6 +10,7 @@
 
         window.warpGlobals['defaultSelectedDates'] = {{ defaultSelectedDates | tojson }};
         window.warpGlobals.today = {{ today | int }};
+        window.warpGlobals['zonePreviewPrefs'] = {{ zonePreviewPrefs | tojson }};
 
         window.warpGlobals.URLs['zoneAutoBook'] = "{{ url_for('xhr.zone.autoBook', zid=zid) }}";
 
@@ -194,6 +195,7 @@
                 <img src="{{ url_for('static', filename='images/schedule_icon_side.png') }}">
             </div>
             <img src="{{ url_for('view.zoneImage', zid=zid) }}">
+            <div class="zonemap-labels" id="zonemap-labels"></div>
         </div>
 
         {% if not isZoneViewer %}

--- a/warp/view.py
+++ b/warp/view.py
@@ -103,6 +103,11 @@ def zone(zid):
     default_time = prefs.get('default_time', [9 * 3600, 17 * 3600])
     default_day = prefs.get('default_day', 'same')
 
+    zonePreviewPrefs = {
+        'show_seat_names': prefs.get('zone_show_seat_names', False),
+        'show_booking_preview': prefs.get('zone_show_booking_preview', False),
+    }
+
     defaultSelectedDates = {
         "slider": default_time
     }
@@ -138,7 +143,8 @@ def zone(zid):
         zid = zid,
         nextWeek=nextWeek,
         today=utils.today(),
-        defaultSelectedDates=defaultSelectedDates)
+        defaultSelectedDates=defaultSelectedDates,
+        zonePreviewPrefs=zonePreviewPrefs)
 
 @bp.route("/zone/image/<zid>")
 def zoneImage(zid):

--- a/warp/xhr/prefs.py
+++ b/warp/xhr/prefs.py
@@ -21,8 +21,10 @@ prefsSchema = {
             "minItems": 2,
             "maxItems": 2
         },
+        "zone_show_seat_names": {"type": "boolean"},
+        "zone_show_booking_preview": {"type": "boolean"},
     },
-    "required": ["default_day", "default_time"],
+    "required": ["default_day", "default_time", "zone_show_seat_names", "zone_show_booking_preview"],
     "additionalProperties": False
 }
 
@@ -32,6 +34,8 @@ def _row_to_prefs(row):
         "default_zone": row['default_zone'],
         "default_day": row['default_day'],
         "default_time": [row['default_time_from'], row['default_time_to']],
+        "zone_show_seat_names": row['zone_show_seat_names'],
+        "zone_show_booking_preview": row['zone_show_booking_preview'],
     }
 
 
@@ -50,6 +54,8 @@ def get_user_prefs(login):
         UserPrefs.default_day,
         UserPrefs.default_time_from,
         UserPrefs.default_time_to,
+        UserPrefs.zone_show_seat_names,
+        UserPrefs.zone_show_booking_preview,
     ).where(UserPrefs.login == login).first()
 
     if row:
@@ -59,6 +65,8 @@ def get_user_prefs(login):
         "default_zone": None,
         "default_day": "same",
         "default_time": [DEFAULT_TIME_FROM, DEFAULT_TIME_TO],
+        "zone_show_seat_names": False,
+        "zone_show_booking_preview": False,
     }
 
 
@@ -80,14 +88,18 @@ def prefs_set():
         UserPrefs.default_zone: _coerce_default_zone(jsonData.get('default_zone')),
         UserPrefs.default_day: jsonData['default_day'],
         UserPrefs.default_time_from: time_from,
-        UserPrefs.default_time_to: time_to
+        UserPrefs.default_time_to: time_to,
+        UserPrefs.zone_show_seat_names: jsonData['zone_show_seat_names'],
+        UserPrefs.zone_show_booking_preview: jsonData['zone_show_booking_preview'],
     }
 
     update = {
         UserPrefs.default_zone: values[UserPrefs.default_zone],
         UserPrefs.default_day: values[UserPrefs.default_day],
         UserPrefs.default_time_from: values[UserPrefs.default_time_from],
-        UserPrefs.default_time_to: values[UserPrefs.default_time_to]
+        UserPrefs.default_time_to: values[UserPrefs.default_time_to],
+        UserPrefs.zone_show_seat_names: values[UserPrefs.zone_show_seat_names],
+        UserPrefs.zone_show_booking_preview: values[UserPrefs.zone_show_booking_preview],
     }
 
     UserPrefs.insert(values).on_conflict(


### PR DESCRIPTION
## Summary

Adds two user preferences (`zone_show_seat_names`, `zone_show_booking_preview`) that overlay seat names and current-period booking usernames as floating labels on the zone map, complementing the existing on-hover preview tooltip.

This PR is an alternative implementation of the seat-labels idea introduced in #55, redone from scratch on top of current `main`. Posted as a separate PR to keep #55 intact for comparison; please consider merging this in place of, or alongside, #55 as you see fit.

## Highlights vs. #55

- New `initSeatLabels` module renders absolutely-positioned label divs into a `#zonemap-labels` container and reacts to `setSeatsData`/`updateAllStates` events on the seat factory
- Content signatures skip rebuilds when nothing has changed (avoids per-slider-tick DOM churn)
- Tooltip suppression for name-only labels is exposed as a method on the labels handle rather than a flag on the factory, decoupling the two modules
- Prefs modal gains two toggles; on save the client dispatches a `warp:prefsSaved` CustomEvent so labels refresh without a page reload
- New `user_prefs` boolean columns via `migration_009` plus `schema.sql` bumped to version 9
- Both new fields are `required` in the JSON schema, so an outdated client gets a 400 rather than silently overwriting saved values
- Minor: bookings.js merged date filter formatting tidy

## Test plan

- [ ] `cd js && npm run build` succeeds
- [ ] Open a zone view; toggle "Show seat names on zone map" in prefs modal; labels appear without reload
- [ ] Toggle "Show booking preview on zone map"; booking usernames appear under seats with current-period bookings
- [ ] Drag the time slider; labels update without visible flicker or lag
- [ ] Hover a seat that has only a name label and no assignments/bookings; tooltip is suppressed
- [ ] Hover a seat with assignments or bookings; tooltip shows, label hides; mouseout restores label
- [ ] In bookings view, set only "From" in the merged date filter; filter applies as `>= from`
- [ ] `curl -X POST .../xhr/prefs` with a payload missing `zone_show_seat_names` returns 400
- [ ] Fresh install (`flask init-db`) produces `db_initialized.version = 9` with the two new columns present

🤖 Generated with [Claude Code](https://claude.com/claude-code)