### PR TITLE
feat(auth): add generic OIDC authentication backend

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -247,7 +247,7 @@ independent of this system-wide window.
 
 ## Authentication providers
 
-WARP ships with built-in username/password auth. Three optional SSO providers are
+WARP ships with built-in username/password auth. Four optional SSO providers are
 available; only one can be active at a time.
 
 | Provider                | Enable with        | Notes                                                                 |
@@ -255,13 +255,17 @@ available; only one can be active at a time.
 | Built-in (default)      | —                  | Users authenticate with a login + password stored in WARP's database. |
 | LDAP / Active Directory | `AUTH_LDAP=true`   | See [LDAP configuration](#ldap--active-directory).                    |
 | Azure Active Directory  | `AUTH_AAD=true`    | See [Azure AD configuration](#azure-active-directory-aad).            |
+| OpenID Connect (OIDC)   | `AUTH_OIDC=true`   | See [OIDC configuration](#openid-connect-oidc).                      |
 | SAML 2.0                | `AUTH_MELLON=true` | See [SAML configuration](#saml-20-via-apache-mod_auth_mellon).        |
 
 All SSO providers support:
 
 - **Auto-provisioning**: a WARP user account is created automatically on first login.
-- **Group mapping**: SSO groups can be mapped to WARP groups (see [Group mapping](#ldap-group-mapping)).
-- **Excluded users**: specific logins can be kept on local password auth even when SSO is active.
+
+Additionally:
+
+- **Group mapping**: LDAP, Azure AD, and OIDC support mapping identity-provider groups to WARP groups (see [Group mapping](#ldap-group-mapping)). SAML/Mellon only has a single default group.
+- **Excluded users**: LDAP and OIDC allow specific logins to be kept on local password auth even when SSO is active. Azure AD and SAML do not support excluded users.
 
 ### Case-insensitive logins
 
@@ -610,6 +614,138 @@ Features: auto-provisioning, display name sync on every login, same group mappin
 | type:          | `boolean`                                                                                                                              |
 | default value: | `False`                                                                                                                                |
 | description:   | When `True`, removes WARP group memberships not matched by the group map on each login. Same semantics as `LDAP_GROUP_STRICT_MAPPING`. |
+
+---
+
+## OpenID Connect (OIDC)
+
+Set `AUTH_OIDC=true` and configure `OIDC_DISCOVERY_URL`, `OIDC_CLIENT_ID`, and
+`OIDC_CLIENT_SECRET`. WARP discovers all endpoints and keys from the IdP's
+`.well-known/openid-configuration` document, so no per-endpoint configuration is
+needed.
+
+Works with any OIDC-compliant identity provider: Keycloak, Authentik, Okta, Auth0,
+Google, Entra ID (generic OIDC mode), and others.
+
+Features: auto-provisioning, display name sync on every login, same group mapping
+model as LDAP, excluded users, ID-token verification (signature, nonce, issuer,
+audience, expiry).
+
+### Configuration variables
+
+| variable:      | `AUTH_OIDC`                                         |
+| :------------- | :-------------------------------------------------- |
+| type:          | `boolean`                                           |
+| default value: | `False`                                             |
+| description:   | Set to `True` to enable OpenID Connect authentication. |
+
+| variable:      | `OIDC_DISCOVERY_URL`                                                                              |
+| :------------- | :------------------------------------------------------------------------------------------------- |
+| type:          | `string`                                                                                           |
+| default value: | `None` (must be defined)                                                                           |
+| description:   | Full URL of the IdP's `.well-known/openid-configuration` document. WARP loads all endpoints and signing keys from here. |
+| example:       | Keycloak: `https://idp.example.org/realms/warp/.well-known/openid-configuration`                    |
+
+| variable:      | `OIDC_CLIENT_ID`                    |
+| :------------- | :---------------------------------- |
+| type:          | `string`                            |
+| default value: | `None` (must be defined)            |
+| description:   | OAuth2 client ID registered at the IdP. |
+
+| variable:      | `OIDC_CLIENT_SECRET`                                                                                    |
+| :------------- | :------------------------------------------------------------------------------------------------------- |
+| type:          | `string`                                                                                                 |
+| default value: | `None` (required for confidential clients)                                                               |
+| description:   | OAuth2 client secret. Treat this like a password. Public clients (SPA/native) may leave this unset. Supports the `_FILE` convention — see [Secrets / `_FILE` convention](#secrets--_file-convention). |
+
+| variable:      | `OIDC_SCOPES`                                                                             |
+| :------------- | :---------------------------------------------------------------------------------------- |
+| type:          | `string` (space-separated)                                                                |
+| default value: | `openid profile email`                                                                    |
+| description:   | OAuth2 scopes requested during the authorisation request. `openid` is required; add others depending on what claims your IdP provides. |
+
+| variable:      | `OIDC_LOGIN_ATTRIBUTE`                                                                                      |
+| :------------- | :---------------------------------------------------------------------------------------------------------- |
+| type:          | `string`                                                                                                    |
+| default value: | `preferred_username`                                                                                        |
+| description:   | OIDC claim used as the WARP login (username). Change to `email` or `sub` if `preferred_username` is not populated by your IdP. |
+
+| variable:      | `OIDC_USER_NAME_ATTRIBUTE`                           |
+| :------------- | :-------------------------------------------------- |
+| type:          | `string`                                            |
+| default value: | `name`                                              |
+| description:   | OIDC claim used as the user's display name in WARP. |
+
+| variable:      | `OIDC_GROUPS_CLAIM`                                                                    |
+| :------------- | :------------------------------------------------------------------------------------- |
+| type:          | `string`                                                                               |
+| default value: | `groups`                                                                               |
+| description:   | Name of the OIDC claim holding the user's group list. Some IdPs use `roles` or `member`. |
+
+| variable:      | `OIDC_GROUP_MAP`                                                                                                |
+| :------------- | :------------------------------------------------------------------------------------------------------------- |
+| type:          | `array` of `[string\|null, string\|null]` pairs                                                                  |
+| default value: | `[ [null, null] ]`                                                                                              |
+| description:   | Maps OIDC groups to WARP groups. Same semantics as [`LDAP_GROUP_MAP`](#ldap-group-mapping).                     |
+
+| variable:      | `OIDC_GROUP_STRICT_MAPPING`                                                                                                             |
+| :------------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| type:          | `boolean`                                                                                                                               |
+| default value: | `False`                                                                                                                                 |
+| description:   | When `True`, removes WARP group memberships not matched by the group map on each login. Same semantics as `LDAP_GROUP_STRICT_MAPPING`. |
+
+| variable:      | `OIDC_EXCLUDED_USERS`                                                                                                                       |
+| :------------- | :------------------------------------------------------------------------------------------------------------------------------------------ |
+| type:          | `array` of `string`                                                                                                                         |
+| default value: | `[]`                                                                                                                                        |
+| description:   | Logins that always authenticate against WARP's local password database, even when OIDC is enabled. Useful for keeping a local admin account. |
+
+| variable:      | `OIDC_HTTPS_SCHEME`                                                                                                                                                   |
+| :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type:          | `string`: `https` or `http`                                                                                                                                          |
+| default value: | `https`                                                                                                                                                               |
+| description:   | Scheme used when constructing the OAuth2 redirect URI. Change to `http` only in local development. Behind a reverse proxy that terminates TLS, keep `https` so the redirect URI matches what is registered at the IdP. |
+
+| variable:      | `OIDC_USERINFO`                                                                                                                      |
+| :------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| type:          | `boolean`                                                                                                                             |
+| default value: | `False`                                                                                                                               |
+| description:   | When `True`, WARP also calls the UserInfo endpoint after the ID token is validated and merges the returned claims. Some IdPs only expose groups in the UserInfo response, not in the ID token. |
+
+### Redirect URI
+
+Register the following redirect URI at your IdP:
+
+```
+https://<your-warp-host>/oidc/callback
+```
+
+The `OIDC_HTTPS_SCHEME` setting controls the scheme of this URI. In production
+behind a reverse proxy, keep it as `https` (the default) even if WARP itself
+listens on `http`, because the proxy rewrites the scheme.
+
+### Client secret `_FILE` convention
+
+The client secret can be supplied via a file (for Docker/Podman secrets) instead
+of an environment variable:
+
+```
+WARP_OIDC_CLIENT_SECRET_FILE=/run/secrets/oidc_client_secret
+```
+
+See [Secrets / `_FILE` convention](#secrets--_file-convention) for details.
+
+### Example configuration (Keycloak)
+
+```sh
+WARP_AUTH_OIDC="true"
+WARP_OIDC_DISCOVERY_URL="https://idp.example.org/realms/warp/.well-known/openid-configuration"
+WARP_OIDC_CLIENT_ID="warp"
+WARP_OIDC_CLIENT_SECRET_FILE="/run/secrets/warp_oidc_client_secret"
+WARP_OIDC_GROUPS_CLAIM="groups"
+WARP_OIDC_GROUP_MAP="[ ['warp-allowed', null], [null, 'Everyone'] ]"
+WARP_OIDC_EXCLUDED_USERS="['admin']"
+```
 
 ---
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -7,7 +7,7 @@
 The behaviour described here is covered by the end-to-end Playwright suite in
 [`e2e/`](e2e/) (see [`e2e/README.md`](e2e/README.md) for how to run it).
 Exceptions that cannot be exercised in a self-contained container: the external
-authentication providers (LDAP §1.2, Azure AD §1.3, SAML §1.4), multi-language
+authentication providers (LDAP §1.2, Azure AD §1.3, OIDC §1.5, SAML §1.4), multi-language
 rendering (§20), mobile layouts (§21), and the map editor's multi-seat marquee
 transforms (§4.3).
 
@@ -50,8 +50,20 @@ Logins are matched case-insensitively by default (`LOGIN_IGNORECASE`): a name en
 - Logging out redirects to the Mellon logout endpoint.
 - Local WARP password is set to `*` (unusable) for SAML-created users.
 
-### 1.5 Changing Password
-- Available from the user menu (only when built-in auth is active — not for SSO/LDAP/AAD users).
+### 1.5 OpenID Connect (OIDC) Authentication
+- When enabled, users are redirected to any OIDC-compliant identity provider (Keycloak, Authentik, Okta, Auth0, Google, Entra ID generic mode, etc.).
+- Configuration is discovery-driven: a single `OIDC_DISCOVERY_URL` loads all endpoints and signing keys from the IdP's `.well-known/openid-configuration`.
+- **Auto-provisioning**: a WARP user account is created automatically on first OIDC login.
+- User name is synced from the IdP on each login.
+- **Group mapping**: IdP groups can be replicated to WARP groups (add/remove), or used purely as access control (allow/deny login). Same semantics as LDAP group mapping.
+- **Strict mapping** mode: removes users from WARP groups that don't match IdP groups on each login.
+- **Excluded users**: specific logins (e.g. local admin) can be excluded from OIDC auth, keeping their local password.
+- A `[null, null]` entry in the group map allows any OIDC user to log in (open access).
+- ID-token verification (signature via JWKS, nonce, issuer, audience, expiry) is handled by Authlib.
+- Optional UserInfo endpoint call for IdPs that only expose groups in the UserInfo response.
+
+### 1.6 Changing Password
+- Available from the user menu (only when built-in auth is active — not for SSO/LDAP/AAD/OIDC users).
 - Requires the current password and a new password.
 - Minimum password length is configurable (default: 6 characters).
 
@@ -758,3 +770,21 @@ Any setting can be provided as an environment variable with the `WARP_` prefix (
 | `AUTH_MELLON`          | unset   | Set to `true` to enable Mellon (SAML) authentication   |
 | `MELLON_ENDPOINT`      | —       | Mellon endpoint path on the Apache proxy, e.g. `/sp`   |
 | `MELLON_DEFAULT_GROUP` | unset   | WARP group assigned to all SAML-provisioned users      |
+
+### 27.4 OIDC Settings (§1.5)
+
+| Setting                    | Default              | Description                                  |
+|----------------------------|----------------------|----------------------------------------------|
+| `AUTH_OIDC`                | unset                | Set to `true` to enable OIDC authentication  |
+| `OIDC_DISCOVERY_URL`       | —                    | Full `.well-known/openid-configuration` URL  |
+| `OIDC_CLIENT_ID`           | —                    | OAuth2 client ID registered at the IdP       |
+| `OIDC_CLIENT_SECRET`       | —                    | OAuth2 client secret (supports `_FILE`)      |
+| `OIDC_SCOPES`              | `openid profile email` | Space-separated scopes requested           |
+| `OIDC_LOGIN_ATTRIBUTE`     | `preferred_username` | Claim used as the WARP login                 |
+| `OIDC_USER_NAME_ATTRIBUTE` | `name`               | Claim used as the display name               |
+| `OIDC_GROUPS_CLAIM`        | `groups`             | Claim holding the user's group list          |
+| `OIDC_GROUP_MAP`           | `[[null, null]]`     | Same semantics as `LDAP_GROUP_MAP`           |
+| `OIDC_GROUP_STRICT_MAPPING`| `false`              | Same semantics as `LDAP_GROUP_STRICT_MAPPING`|
+| `OIDC_EXCLUDED_USERS`      | `[]`                 | Logins kept on local password auth           |
+| `OIDC_HTTPS_SCHEME`        | `https`              | Scheme used for the redirect URI             |
+| `OIDC_USERINFO`            | `false`              | Also call the UserInfo endpoint and merge claims |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ I've quickly evaluated a couple of existing solutions, but they were either too 
 - **Translations**: Currently supports English, German, French, Spanish, and Polish.
 - **SAML2.0**: Via Apache [mod_auth_mellon](https://github.com/latchset/mod_auth_mellon) module.
 - **LDAP/Active Directory**: Via LDAP3 library.
+- **Azure AD**: Via Microsoft Authentication Library (MSAL).
+- **OIDC / OpenID Connect**: Generic SSO via any compliant identity provider (Authlib).
 
 See [FEATURES.md](FEATURES.md) for a detailed description of all functionality, roles, booking rules, and configuration options.
 New to the concepts? Start with the [GLOSSARY.md](GLOSSARY.md), and read
@@ -109,7 +111,7 @@ WARP_DATABASE_USER=user
 WARP_DATABASE_PASSWORD=password
 ```
 
-For all configuration options — environment variables, secret key generation, language, and authentication providers (LDAP, Azure AD, SAML) — see [CONFIGURATION.md](CONFIGURATION.md).
+For all configuration options — environment variables, secret key generation, language, and authentication providers (LDAP, Azure AD, OIDC, SAML) — see [CONFIGURATION.md](CONFIGURATION.md).
 
 For ready-to-use deployment examples (Docker Compose, Podman Quadlet with systemd) see [`containers/README.md`](containers/README.md).
 

--- a/containers/compose/compose.yaml
+++ b/containers/compose/compose.yaml
@@ -20,6 +20,12 @@ services:
       WARP_SECRET_KEY_FILE: /run/secrets/warp_secret_key
       WARP_DATABASE_POST_INIT_SCRIPTS: '["sql/sample_data.sql"]'
       WARP_LANGUAGE_FILE: 'i18n/en.js'
+      # OpenID Connect (OIDC) — uncomment to enable, see CONFIGURATION.md
+      # WARP_AUTH_OIDC: 'true'
+      # WARP_OIDC_DISCOVERY_URL: 'https://idp.example.org/realms/warp/.well-known/openid-configuration'
+      # WARP_OIDC_CLIENT_ID: 'warp'
+      # WARP_OIDC_CLIENT_SECRET_FILE: /run/secrets/warp_oidc_client_secret
+      # WARP_OIDC_GROUP_MAP: '[ ["warp-allowed", null], [null, "Everyone"] ]'
     secrets:
       - warp_db_password
       - warp_secret_key
@@ -37,3 +43,5 @@ secrets:
     file: ./secrets/db_password.txt
   warp_secret_key:
     file: ./secrets/secret_key.txt
+  # warp_oidc_client_secret:
+  #   file: ./secrets/oidc_client_secret.txt

--- a/containers/compose/secrets/README.md
+++ b/containers/compose/secrets/README.md
@@ -5,3 +5,4 @@ These files provide default values for `docker compose up` out of the box.
 
 - `db_password.txt` — PostgreSQL superuser password (shared by the DB and app services)
 - `secret_key.txt` — Flask session signing key (generate with `python -c 'import os; print(os.urandom(16))'`)
+- `oidc_client_secret.txt` (optional) — OAuth2 client secret for OIDC authentication; only needed when `WARP_AUTH_OIDC=true`

--- a/containers/quadlet/warp-app.container
+++ b/containers/quadlet/warp-app.container
@@ -32,5 +32,13 @@ Environment=WARP_LANGUAGE_FILE=i18n/en.js
 # Environment=WARP_OMITTED_WEEKDAYS=[5, 6]
 # Environment=WARP_MIN_PASSWORD_LENGTH=8
 
+# OpenID Connect (OIDC) authentication — see CONFIGURATION.md
+# Environment=WARP_AUTH_OIDC=true
+# Environment=WARP_OIDC_DISCOVERY_URL=https://idp.example.org/realms/warp/.well-known/openid-configuration
+# Environment=WARP_OIDC_CLIENT_ID=warp
+# Secret=warp-oidc-client-secret,type=env,target=WARP_OIDC_CLIENT_SECRET
+# Environment=WARP_OIDC_GROUP_MAP=[ ["warp-allowed", null], [null, "Everyone"] ]
+# Create the podman secret with: podman secret create warp-oidc-client-secret <file>
+
 [Install]
 WantedBy=multi-user.target default.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ psycopg[binary]
 orjson
 ldap3
 msal
+authlib
 pycryptodome

--- a/tests/test_oidc_metadata.py
+++ b/tests/test_oidc_metadata.py
@@ -1,0 +1,185 @@
+# Unit tests for warp.auth_oidc.oidcGetUserMetadata
+#
+# These tests exercise the claim → metadata mapping logic (group access control,
+# open access, unconditional groups, deny) without a running Flask app or IdP.
+#
+# Run with:  python -m pytest tests/  (from the repo root)
+
+import pytest
+
+# We need a minimal Flask app context because oidcGetUserMetadata reads
+# flask.current_app.config. Build one with a fixed config.
+
+def _make_app(**overrides):
+    """Create a minimal Flask app with the given OIDC config overrides."""
+    import flask
+    app = flask.Flask(__name__)
+    app.config.update({
+        'OIDC_LOGIN_ATTRIBUTE': 'preferred_username',
+        'OIDC_USER_NAME_ATTRIBUTE': 'name',
+        'OIDC_GROUPS_CLAIM': 'groups',
+        'OIDC_GROUP_MAP': [[None, None]],   # open access by default
+    })
+    app.config.update(overrides)
+    return app
+
+
+def test_open_access_null_null():
+    """[null, null] allows any user regardless of groups."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(OIDC_GROUP_MAP=[[None, None]])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({'preferred_username': 'alice', 'name': 'Alice'})
+    assert result is not None
+    assert result['login'] == 'alice'
+    assert result['userName'] == 'Alice'
+    assert result['groups'] == []
+
+
+def test_conditional_group_deny():
+    """User not in any listed group is denied."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(OIDC_GROUP_MAP=[['admins', None]])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'preferred_username': 'bob',
+            'name': 'Bob',
+            'groups': ['users']
+        })
+    assert result is None
+
+
+def test_conditional_group_allow():
+    """User in a listed group is allowed and gets the mapped WARP group."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(OIDC_GROUP_MAP=[['admins', 'WARP-Admins']])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'preferred_username': 'carol',
+            'name': 'Carol',
+            'groups': ['admins']
+        })
+    assert result is not None
+    assert result['login'] == 'carol'
+    assert result['groups'] == ['WARP-Admins']
+
+
+def test_conditional_group_no_warp_group():
+    """Mapped group with null WARP group grants access but adds no groups."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(OIDC_GROUP_MAP=[['admins', None]])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'preferred_username': 'dave',
+            'name': 'Dave',
+            'groups': ['admins']
+        })
+    assert result is not None
+    assert result['groups'] == []
+
+
+def test_unconditional_group():
+    """[null, 'WARP-Group'] always adds the WARP group, but does not grant access alone."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    # Without an access-granting entry, unconditional groups alone deny
+    app = _make_app(OIDC_GROUP_MAP=[[None, 'Everyone']])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'preferred_username': 'eve',
+            'name': 'Eve',
+            'groups': []
+        })
+    assert result is None  # no access-granting entry
+
+
+def test_unconditional_group_with_access():
+    """Unconditional group + access-granting entry."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(OIDC_GROUP_MAP=[['admins', None], [None, 'Everyone']])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'preferred_username': 'frank',
+            'name': 'Frank',
+            'groups': ['admins']
+        })
+    assert result is not None
+    assert result['groups'] == ['Everyone']
+
+
+def test_open_access_plus_groups():
+    """[null, null] + conditional groups: open access + group sync."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(OIDC_GROUP_MAP=[[None, None], ['devs', 'Developers']])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'preferred_username': 'grace',
+            'name': 'Grace',
+            'groups': ['devs']
+        })
+    assert result is not None
+    assert result['groups'] == ['Developers']
+
+
+def test_missing_login_claim():
+    """Missing login claim returns None."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app()
+    with app.test_request_context():
+        result = oidcGetUserMetadata({'name': 'NoLogin'})
+    assert result is None
+
+
+def test_name_fallback_to_login():
+    """When name claim is missing, login is used as userName."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app()
+    with app.test_request_context():
+        result = oidcGetUserMetadata({'preferred_username': 'heidi'})
+    assert result is not None
+    assert result['userName'] == 'heidi'
+
+
+def test_custom_claims():
+    """Custom claim attribute names are respected."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(
+        OIDC_LOGIN_ATTRIBUTE='email',
+        OIDC_USER_NAME_ATTRIBUTE='nickname',
+        OIDC_GROUPS_CLAIM='roles',
+    )
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'email': 'ivan@example.org',
+            'nickname': 'Ivan',
+            'roles': ['editor'],
+        })
+    assert result is not None
+    assert result['login'] == 'ivan@example.org'
+    assert result['userName'] == 'Ivan'
+
+
+def test_groups_claim_missing():
+    """Missing groups claim is treated as empty list."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(OIDC_GROUP_MAP=[['admins', None]])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'preferred_username': 'judy',
+            'name': 'Judy',
+            # no 'groups' key at all
+        })
+    assert result is None  # not in admins, denied
+
+
+def test_groups_claim_null():
+    """groups claim that is null/None is treated as empty list."""
+    from warp.auth_oidc import oidcGetUserMetadata
+    app = _make_app(OIDC_GROUP_MAP=[[None, None]])
+    with app.test_request_context():
+        result = oidcGetUserMetadata({
+            'preferred_username': 'karl',
+            'name': 'Karl',
+            'groups': None,
+        })
+    assert result is not None
+    assert result['groups'] == []

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -24,6 +24,7 @@ def create_app():
     from . import auth_mellon
     from . import auth_ldap
     from . import auth_aad
+    from . import auth_oidc
     if 'AUTH_MELLON' in app.config \
        and 'MELLON_ENDPOINT' in app.config \
        and app.config['AUTH_MELLON']:
@@ -34,6 +35,8 @@ def create_app():
     elif 'AUTH_AAD' in app.config \
        and app.config['AUTH_AAD']:
         app.register_blueprint(auth_aad.bp)
+    elif app.config.get('AUTH_OIDC'):
+        app.register_blueprint(auth_oidc.bp)
     else:
         app.register_blueprint(auth.bp)
 

--- a/warp/auth.py
+++ b/warp/auth.py
@@ -66,6 +66,45 @@ def logout():
 
 bp.route('/logout')(logout)
 
+def applyUserMetadata(login, userData, *, strictMapping=False, warnPrefix="SSO"):
+    """Upsert the user, sync display name, and reconcile group membership from
+    userData['userName'] and userData['groups']. Returns the canonical stored login.
+
+    Shared by all SSO backends (LDAP, AAD, OIDC). Runs inside an atomic block."""
+    with DB.atomic():
+        existing = Users.select(Users.login, Users.name).where(loginMatch(login)).first()
+        if existing is None:
+            Users.insert({
+                Users.login: login,
+                Users.name: userData["userName"],
+                Users.account_type: ACCOUNT_TYPE_USER,
+                Users.password: '*'
+            }).execute()
+        else:
+            login = existing['login']    # canonical stored login (case may differ)
+            if existing['name'] != userData["userName"]:
+                Users.update({Users.name: userData["userName"]}).where(Users.login == login).execute()
+
+        existingGroups = Users.select( Users.login ) \
+            .where( Users.account_type == ACCOUNT_TYPE_GROUP ) \
+            .where( Users.login.in_(userData["groups"]) ) \
+            .tuples()
+        existingGroups = [i[0] for i in existingGroups]
+
+        if len(existingGroups) != len(userData["groups"]):
+            print(f"{warnPrefix} WARNING: some of the groups defined in the IdP and mapped via group map doesn't exist in Warp")
+
+        insertData = [ {Groups.login: login, Groups.group: i} for i in existingGroups ]
+        Groups.insert(insertData).on_conflict_ignore().execute()
+
+        if strictMapping:
+            Groups.delete() \
+                .where( Groups.login == login ) \
+                .where( Groups.group.not_in(existingGroups) ) \
+                .execute()
+
+    return login
+
 changePasswordSchema = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",

--- a/warp/auth_aad.py
+++ b/warp/auth_aad.py
@@ -86,7 +86,6 @@ def aadGetUserMetadata(userData):
 
 
 	aadGroupMap = flask.current_app.config.get('AAD_GROUP_MAP')
-	print(aadGroupMap)
 
 	for aadGroup,warpGroup in aadGroupMap:
 		if aadGroup is None or (warpGroup and aadGroup in userData['groups']):
@@ -95,41 +94,11 @@ def aadGetUserMetadata(userData):
 	return ret
 
 def aadApplyUserMetadata(userData):
-	with DB.atomic():
-		login = userData['login']
-		existing = Users.select(Users.login, Users.name).where(warp.auth.loginMatch(login)).first()
-		if existing is None:
-			Users.insert({
-				Users.login: login,
-				Users.name: userData["userName"],
-				Users.account_type: ACCOUNT_TYPE_USER,
-				Users.password: '*'
-			}).execute()
-		else:
-			login = existing['login']    # canonical stored login (case may differ)
-			if existing['name'] != userData["userName"]:
-				Users.update({Users.name: userData["userName"]}).where(Users.login == login).execute()
-
-		existingGroups = Users.select( Users.login ) \
-			.where( Users.account_type == ACCOUNT_TYPE_GROUP ) \
-			.where( Users.login.in_(userData["groups"]) ) \
-			.tuples()
-		existingGroups = [i[0] for i in existingGroups]
-
-		if len(existingGroups) != len(userData["groups"]):
-			print("AAD WARNING: some of the groups defined in AAD and mapped via AAD_GROUP_MAP doesn't exist in Warp")
-
-		insertData = [ {Groups.login: login, Groups.group: i} for i in existingGroups ]
-		Groups.insert(insertData).on_conflict_ignore().execute()
-
-		strictMapping = flask.current_app.config.get('AAD_GROUP_STRICT_MAPPING')
-		if strictMapping:
-			Groups.delete() \
-				.where( Groups.login == login ) \
-				.where( Groups.group.not_in(existingGroups) ) \
-				.execute()
-
-	return login
+    strictMapping = flask.current_app.config.get('AAD_GROUP_STRICT_MAPPING')
+    return warp.auth.applyUserMetadata(
+        userData['login'], userData,
+        strictMapping=strictMapping,
+        warnPrefix="AAD")
 
 bp.route('/logout')(warp.auth.logout)
 bp.before_app_request(warp.auth.session)

--- a/warp/auth_ldap.py
+++ b/warp/auth_ldap.py
@@ -138,42 +138,11 @@ def ldapGetUserMetadata(login,ldapConnection):
 
 def ldapApplyUserMetadata(login,userData):
 
-    with DB.atomic():
-
-        existing = Users.select(Users.login, Users.name).where(warp.auth.loginMatch(login)).first()
-        if existing is None:
-            Users.insert({
-                Users.login: login,
-                Users.name: userData["userName"],
-                Users.account_type: ACCOUNT_TYPE_USER,
-                Users.password: '*'
-            }).execute()
-        else:
-            login = existing['login']    # canonical stored login (case may differ)
-            if existing['name'] != userData["userName"]:
-                Users.update({Users.name: userData["userName"]}).where(Users.login == login).execute()
-
-        existingGroups = Users.select( Users.login ) \
-            .where( Users.account_type == ACCOUNT_TYPE_GROUP ) \
-            .where( Users.login.in_(userData["groups"]) ) \
-            .tuples()
-        existingGroups = [i[0] for i in existingGroups]
-
-        if len(existingGroups) != len(userData["groups"]):
-            print("LDAP WARNING: some of the groups defined in LDAP and mapped via LDAP_GROUP_MAP doesn't exist in Warp")
-
-        insertData = [ {Groups.login: login, Groups.group: i} for i in existingGroups ]
-        #TODO: check if the materialized view is updated if no changes
-        Groups.insert(insertData).on_conflict_ignore().execute()
-
-        strictMapping = flask.current_app.config.get('LDAP_GROUP_STRICT_MAPPING')
-        if strictMapping:
-            Groups.delete() \
-                .where( Groups.login == login ) \
-                .where( Groups.group.not_in(existingGroups) ) \
-                .execute()
-
-    return login
+    strictMapping = flask.current_app.config.get('LDAP_GROUP_STRICT_MAPPING')
+    return warp.auth.applyUserMetadata(
+        login, userData,
+        strictMapping=strictMapping,
+        warnPrefix="LDAP")
 
 
 

--- a/warp/auth_oidc.py
+++ b/warp/auth_oidc.py
@@ -1,0 +1,236 @@
+import flask
+import sys
+from urllib.parse import quote
+from warp.db import *
+import warp.auth
+from . import utils
+
+bp = flask.Blueprint('auth', __name__)
+
+# ---------------------------------------------------------------------------
+# OIDC client (Authlib)
+# ---------------------------------------------------------------------------
+
+_oauth = None
+
+def _get_oauth():
+    """Lazy-initialise the Authlib OAuth registry on first use."""
+    global _oauth
+    if _oauth is not None:
+        return _oauth
+
+    from authlib.integrations.flask_client import OAuth
+
+    _oauth = OAuth(flask.current_app)
+    _oauth.register(
+        name="oidc",
+        server_metadata_url=flask.current_app.config['OIDC_DISCOVERY_URL'],
+        client_id=flask.current_app.config['OIDC_CLIENT_ID'],
+        client_secret=flask.current_app.config.get('OIDC_CLIENT_SECRET'),
+        client_kwargs={
+            "scope": flask.current_app.config.get('OIDC_SCOPES', 'openid profile email'),
+            "code_challenge_method": "S256",
+        },
+    )
+    return _oauth
+
+
+# ---------------------------------------------------------------------------
+# Claim → metadata mapping
+# ---------------------------------------------------------------------------
+
+def oidcGetUserMetadata(claims):
+    """Map OIDC claims to a WARP user-metadata dict, applying group-map
+    access control (same semantics as LDAP's ldapGetUserMetadata).
+
+    Returns None when the user has no matching group and no [null,null] entry
+    (deny access).
+    """
+    config = flask.current_app.config
+
+    login_claim = config.get('OIDC_LOGIN_ATTRIBUTE', 'preferred_username')
+    name_claim = config.get('OIDC_USER_NAME_ATTRIBUTE', 'name')
+    groups_claim = config.get('OIDC_GROUPS_CLAIM', 'groups')
+
+    login = claims.get(login_claim)
+    if not login:
+        print("OIDC WARNING: login claim missing from ID token", file=sys.stderr, flush=True)
+        return None
+
+    ret = {
+        'login':    login,
+        'userName': claims.get(name_claim, login),
+        'groups':   [],
+    }
+
+    idpGroups = claims.get(groups_claim, []) or []
+    groupMap = config.get('OIDC_GROUP_MAP', [[None, None]])
+
+    loginAllowed = False
+    for idpGroup, warpGroup in groupMap:
+        if idpGroup is None and warpGroup is None:
+            loginAllowed = True          # [null,null] => open access
+            continue
+        if idpGroup is None:
+            ret['groups'].append(warpGroup)   # unconditional group assignment
+            continue
+        if idpGroup in idpGroups:
+            loginAllowed = True
+            if warpGroup:
+                ret['groups'].append(warpGroup)
+
+    if not loginAllowed:
+        return None                      # no matching group and no [null,null] => deny
+
+    return ret
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    """OIDC login entry point.
+
+    When OIDC_EXCLUDED_USERS is empty (default), /login immediately redirects
+    to the IdP — clean SSO-only experience.
+
+    When OIDC_EXCLUDED_USERS is non-empty, /login renders the local
+    username/password form plus a "Sign in with SSO" button that links to
+    /oidc/start. A POST to /login is handled by the local warp.auth.login()
+    logic, but only for logins present in OIDC_EXCLUDED_USERS.
+    """
+    # Clear session to force re-login (same as other backends)
+    flask.session.clear()
+
+    excluded_users = flask.current_app.config.get('OIDC_EXCLUDED_USERS', [])
+
+    # --- SSO-only path: redirect straight to IdP --------------------------
+    if not excluded_users:
+        return _start_oidc_flow()
+
+    # --- Mixed path: local form + SSO button ------------------------------
+    if flask.request.method == 'POST':
+        u = flask.request.form.get('login')
+
+        if u not in excluded_users:
+            flask.flash("Please sign in with SSO")
+        else:
+            # Delegate to local password auth for excluded users
+            return warp.auth.login()
+
+        return flask.render_template('login.html', sso_enabled=True)
+
+    return flask.render_template('login.html', sso_enabled=True)
+
+
+@bp.route('/oidc/start')
+def oidc_start():
+    """Dedicated route for the "Sign in with SSO" button (used when
+    OIDC_EXCLUDED_USERS is non-empty and the local form is shown)."""
+    flask.session.clear()
+    return _start_oidc_flow()
+
+
+@bp.route('/oidc/callback')
+def oidc_callback():
+    """OIDC callback — exchanges the auth code for tokens, verifies the ID
+    token, extracts claims, and provisions the user."""
+    config = flask.current_app.config
+    app_root_uri = flask.url_for('view.index')
+
+    try:
+        oauth = _get_oauth()
+        token = oauth.oidc.authorize_access_token()
+    except Exception as e:
+        print(f"OIDC WARNING: token exchange failed: {e}", file=sys.stderr, flush=True)
+        return flask.render_template("auth_error.html",
+            error="token_exchange_failed",
+            application_root_uri=app_root_uri)
+
+    # Authlib parses and verifies the ID token (iss, aud, exp, nonce, signature).
+    claims = token.get('userinfo')
+
+    # Store the raw ID token for RP-initiated logout (before any early return)
+    id_token = token.get('id_token')
+    if id_token:
+        flask.session['oidc_id_token'] = id_token
+
+    # Optionally call the UserInfo endpoint and merge claims
+    if config.get('OIDC_USERINFO'):
+        try:
+            userinfo = oauth.oidc.userinfo()
+            if userinfo:
+                # Merge userinfo claims on top (userinfo takes precedence)
+                merged = dict(claims) if claims else {}
+                merged.update(userinfo)
+                claims = merged
+        except Exception as e:
+            print(f"OIDC WARNING: userinfo endpoint failed: {e}", file=sys.stderr, flush=True)
+
+    if not claims:
+        return flask.render_template("auth_error.html",
+            error="no_claims",
+            application_root_uri=app_root_uri)
+
+    metadata = oidcGetUserMetadata(claims)
+    if metadata is None:
+        return flask.render_template("auth_error.html",
+            error="access_denied",
+            application_root_uri=app_root_uri)
+
+    strictMapping = config.get('OIDC_GROUP_STRICT_MAPPING', False)
+    login = warp.auth.applyUserMetadata(
+        metadata['login'], metadata,
+        strictMapping=strictMapping,
+        warnPrefix="OIDC")
+
+    flask.session['login'] = login
+    flask.session['login_time'] = utils.now()
+
+    return flask.redirect(app_root_uri)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _start_oidc_flow():
+    """Begin the OIDC redirect flow (authorize_redirect)."""
+    config = flask.current_app.config
+    oauth = _get_oauth()
+    redirect_uri = flask.url_for('.oidc_callback', _external=True,
+                                  _scheme=config.get('OIDC_HTTPS_SCHEME', 'https'))
+    return oauth.oidc.authorize_redirect(redirect_uri)
+
+
+# ---------------------------------------------------------------------------
+# Logout & session gate
+# ---------------------------------------------------------------------------
+
+def logout():
+    config = flask.current_app.config
+    id_token = flask.session.pop('oidc_id_token', None)
+    flask.session.clear()
+
+    # RP-initiated logout: redirect to the IdP's end_session_endpoint
+    # so the user is also logged out from the IdP (e.g. Keycloak).
+    try:
+        oauth = _get_oauth()
+        end_session_endpoint = oauth.oidc.load_server_metadata().get('end_session_endpoint')
+    except Exception:
+        end_session_endpoint = None
+
+    if end_session_endpoint:
+        logout_uri = flask.url_for('auth.login', _external=True,
+                                    _scheme=config.get('OIDC_HTTPS_SCHEME', 'https'))
+        params = ['post_logout_redirect_uri=' + quote(logout_uri, safe='')]
+        if id_token:
+            params.append('id_token_hint=' + quote(id_token, safe=''))
+        return flask.redirect(end_session_endpoint + '?' + '&'.join(params))
+
+    return flask.redirect(flask.url_for('auth.login'))
+
+bp.route('/logout')(logout)
+bp.before_app_request(warp.auth.session)

--- a/warp/config.py
+++ b/warp/config.py
@@ -74,6 +74,17 @@ class DefaultSettings(object):
     AAD_GROUP_MAP = [ [None,None] ]
     AAD_GROUP_STRICT_MAPPING = False
 
+    # OIDC defaults
+    OIDC_SCOPES = "openid profile email"
+    OIDC_LOGIN_ATTRIBUTE = "preferred_username"
+    OIDC_USER_NAME_ATTRIBUTE = "name"
+    OIDC_GROUPS_CLAIM = "groups"
+    OIDC_GROUP_MAP = [ [None,None] ]
+    OIDC_GROUP_STRICT_MAPPING = False
+    OIDC_EXCLUDED_USERS = []
+    OIDC_HTTPS_SCHEME = "https"
+    OIDC_USERINFO = False
+
     ### LDAP variables to be configured
     # AUTH_LDAP = True
     # LDAP_SERVER_URL = "ldap://server:port"
@@ -82,6 +93,12 @@ class DefaultSettings(object):
     # LDAP_GROUP_SEARCH_BASE = "ou=groups,dc=example,dc=org"
     # LDAP_TLS_VERSION (optional)
     # LDAP_TLS_CIPHERS (optional)
+
+    ### OIDC variables to be configured
+    # AUTH_OIDC = True
+    # OIDC_DISCOVERY_URL = "https://idp.example.org/.well-known/openid-configuration"
+    # OIDC_CLIENT_ID = "warp"
+    # OIDC_CLIENT_SECRET
 
     # these settings are available, but should not have default value
     # set them up in DevelopmentSettings or via environment
@@ -213,6 +230,7 @@ _ENV_SETTINGS = {
     "AUTH_LDAP":                  _fmt_bool,
     "AUTH_MELLON":                _fmt_bool,
     "AUTH_AAD":                   _fmt_bool,
+    "AUTH_OIDC":                  _fmt_bool,
     # LDAP
     "LDAP_SERVER_URL":            _fmt_str,
     "LDAP_AUTH_TYPE":             _fmt_str,
@@ -238,6 +256,20 @@ _ENV_SETTINGS = {
     "AAD_LOGIN_ATTRIBUTE":        _fmt_str,
     "AAD_GROUP_MAP":              _fmt_json(_GROUP_MAP),
     "AAD_GROUP_STRICT_MAPPING":   _fmt_bool,
+    # OIDC
+    "OIDC_DISCOVERY_URL":         _fmt_str,
+    "OIDC_CLIENT_ID":             _fmt_str,
+    "OIDC_CLIENT_SECRET":         _fmt_str,
+    "OIDC_CLIENT_SECRET_FILE":    _fmt_file,
+    "OIDC_SCOPES":                _fmt_str,
+    "OIDC_LOGIN_ATTRIBUTE":       _fmt_str,
+    "OIDC_USER_NAME_ATTRIBUTE":   _fmt_str,
+    "OIDC_GROUPS_CLAIM":          _fmt_str,
+    "OIDC_GROUP_MAP":             _fmt_json(_GROUP_MAP),
+    "OIDC_GROUP_STRICT_MAPPING":  _fmt_bool,
+    "OIDC_EXCLUDED_USERS":        _fmt_json(_ARRAY_OF_STRINGS),
+    "OIDC_HTTPS_SCHEME":          _fmt_str,
+    "OIDC_USERINFO":              _fmt_bool,
     # Mellon (SAML)
     "MELLON_ENDPOINT":            _fmt_str,
     "MELLON_DEFAULT_GROUP":       _fmt_str,

--- a/warp/static/i18n/de.json
+++ b/warp/static/i18n/de.json
@@ -127,7 +127,8 @@
             "Add seats": "Sitze hinzufügen",
             "Restore": "Wiederherstellen",
             "Edit": "Bearbeiten",
-            "Yes, delete": "Ja, löschen"
+            "Yes, delete": "Ja, löschen",
+            "Sign in with SSO": "Mit SSO anmelden"
         },
         "Password": "Passwort",
         "Bookings only": "Nur Buchungen",
@@ -341,6 +342,12 @@
             "Cancel": "Abbrechen",
             "Action cancelled": "Aktion abgebrochen"
         },
-        "No filter": "Kein Filter"
+        "No filter": "Kein Filter",
+        "Logout": "Abmelden",
+        "Bookings": "Buchungen",
+        "Authentication error": "Authentifizierungsfehler",
+        "Access denied: you are not a member of an allowed group.": "Zugriff verweigert: Sie sind kein Mitglied einer zulässigen Gruppe.",
+        "Authentication failed: could not exchange the authorisation code.": "Authentifizierung fehlgeschlagen: Der Autorisierungscode konnte nicht ausgetauscht werden.",
+        "Authentication failed: no user claims received.": "Authentifizierung fehlgeschlagen: keine Benutzerdaten erhalten."
     }
 }

--- a/warp/static/i18n/en.json
+++ b/warp/static/i18n/en.json
@@ -127,7 +127,8 @@
             "Add seats": "Add seats",
             "Restore": "Restore",
             "Edit": "Edit",
-            "Yes, delete": "Yes, delete"
+            "Yes, delete": "Yes, delete",
+            "Sign in with SSO": "Sign in with SSO"
         },
         "Password": "Password",
         "Bookings only": "Bookings only",
@@ -341,6 +342,12 @@
             "Cancel": "Cancel",
             "Action cancelled": "Action cancelled"
         },
-        "No filter": "No filter"
+        "No filter": "No filter",
+        "Logout": "Logout",
+        "Bookings": "Bookings",
+        "Authentication error": "Authentication error",
+        "Access denied: you are not a member of an allowed group.": "Access denied: you are not a member of an allowed group.",
+        "Authentication failed: could not exchange the authorisation code.": "Authentication failed: could not exchange the authorisation code.",
+        "Authentication failed: no user claims received.": "Authentication failed: no user claims received."
     }
 }

--- a/warp/static/i18n/es.json
+++ b/warp/static/i18n/es.json
@@ -127,7 +127,8 @@
             "Add seats": "Agregar Asientos",
             "Restore": "Restaurar",
             "Edit": "Editar",
-            "Yes, delete": "Sí, eliminar"
+            "Yes, delete": "Sí, eliminar",
+            "Sign in with SSO": "Iniciar sesión con SSO"
         },
         "Password": "Contraseña",
         "Bookings only": "Solo reservas",
@@ -341,6 +342,12 @@
             "Cancel": "Cancelar",
             "Action cancelled": "Acción cancelada"
         },
-        "No filter": "Sin filtro"
+        "No filter": "Sin filtro",
+        "Logout": "Cerrar sesión",
+        "Bookings": "Reservas",
+        "Authentication error": "Error de autenticación",
+        "Access denied: you are not a member of an allowed group.": "Acceso denegado: no es miembro de un grupo permitido.",
+        "Authentication failed: could not exchange the authorisation code.": "Error de autenticación: no se pudo intercambiar el código de autorización.",
+        "Authentication failed: no user claims received.": "Error de autenticación: no se recibieron datos del usuario."
     }
 }

--- a/warp/static/i18n/fr.json
+++ b/warp/static/i18n/fr.json
@@ -127,7 +127,8 @@
             "Add seats": "Ajouter siège",
             "Restore": "Restaurer",
             "Edit": "Éditer",
-            "Yes, delete": "Oui, supprimer"
+            "Yes, delete": "Oui, supprimer",
+            "Sign in with SSO": "Se connecter avec SSO"
         },
         "Password": "Mot de passe",
         "Bookings only": "Réservations seulement",
@@ -341,6 +342,12 @@
             "Cancel": "Annuler",
             "Action cancelled": "Action annulée"
         },
-        "No filter": "Sans filtre"
+        "No filter": "Sans filtre",
+        "Logout": "Déconnexion",
+        "Bookings": "Réservations",
+        "Authentication error": "Erreur d'authentification",
+        "Access denied: you are not a member of an allowed group.": "Accès refusé : vous n'êtes pas membre d'un groupe autorisé.",
+        "Authentication failed: could not exchange the authorisation code.": "Échec de l'authentification : impossible d'échanger le code d'autorisation.",
+        "Authentication failed: no user claims received.": "Échec de l'authentification : aucune donnée utilisateur reçue."
     }
 }

--- a/warp/static/i18n/pl.json
+++ b/warp/static/i18n/pl.json
@@ -127,7 +127,8 @@
             "Add seats": "Dodaj miejsca",
             "Restore": "Przywróć",
             "Edit": "Edycja",
-            "Yes, delete": "Tak, usuń"
+            "Yes, delete": "Tak, usuń",
+            "Sign in with SSO": "Zaloguj przez SSO"
         },
         "Password": "Hasło",
         "Bookings only": "Tylko rezerwacje",
@@ -341,6 +342,12 @@
             "Cancel": "Anuluj",
             "Action cancelled": "Akcja anulowana"
         },
-        "No filter": "Bez filtra"
+        "No filter": "Bez filtra",
+        "Logout": "Wyloguj",
+        "Bookings": "Rezerwacje",
+        "Authentication error": "Błąd uwierzytelniania",
+        "Access denied: you are not a member of an allowed group.": "Brak dostępu: nie jesteś członkiem dozwolonej grupy.",
+        "Authentication failed: could not exchange the authorisation code.": "Uwierzytelnianie nie powiodło się: nie udało się wymienić kodu autoryzacji.",
+        "Authentication failed: no user claims received.": "Uwierzytelnianie nie powiodło się: nie otrzymano danych użytkownika."
     }
 }

--- a/warp/templates/auth_error.html
+++ b/warp/templates/auth_error.html
@@ -1,0 +1,65 @@
+{% extends 'base.html' %}
+
+{% block header %}
+    {{ super() }}
+
+    <style>
+        html, body {
+            height: 100%;
+            width: 100%;
+        }
+        .auth-error-container {
+            margin: auto;
+            width: 400px;
+            height: 70%;
+        }
+        .auth-error-message {
+          color: #F44336;
+          padding-bottom: 20px;
+        }
+
+    </style>
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+
+    <nav>
+        <div class="nav-wrapper">
+            <div class="center"><img class="logo" src="{{ url_for('static', filename='images/logo.png') }}"></div>
+        </div>
+    </nav>
+
+    <div class="auth-error-container valign-wrapper">
+      <div class="row center-align">
+
+        <div class="col s12">
+          <h5 class="auth-error-message TR">Authentication error</h5>
+        </div>
+
+        <div class="col s12">
+        {% if error == 'token_exchange_failed' %}
+          <p class="TR">Authentication failed: could not exchange the authorisation code.</p>
+        {% elif error == 'no_claims' %}
+          <p class="TR">Authentication failed: no user claims received.</p>
+        {% elif error == 'access_denied' %}
+          <p class="TR">Access denied: you are not a member of an allowed group.</p>
+        {% elif result and result.get('error_description') %}
+          <p>{{ result.get('error_description') }}</p>
+        {% elif result and result.get('error') %}
+          <p>{{ result.get('error') }}</p>
+        {% else %}
+          <p class="TR">An unknown authentication error occurred.</p>
+        {% endif %}
+        </div>
+
+        <div class="col s12">
+          {# Go through /logout to also end the IdP session (e.g. Keycloak),
+             so the user can try again with a different account. #}
+          <a href="{{ url_for('auth.logout') }}" class="btn waves-effect waves-light TR">btn.Ok</a>
+        </div>
+
+      </div>
+    </div>
+
+{% endblock %}

--- a/warp/templates/login.html
+++ b/warp/templates/login.html
@@ -63,6 +63,12 @@
           <button class="btn waves-effect waves-light TR" type="submit" name="submit">btn.Login</button>
         </div>
 
+        {% if sso_enabled %}
+        <div class="col s12" style="margin-top: 16px;">
+          <a href="{{ url_for('auth.oidc_start') }}" class="btn waves-effect waves-light TR">btn.Sign in with SSO</a>
+        </div>
+        {% endif %}
+
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

Add a clean, generic OpenID Connect (OIDC) authentication backend to WARP, on par with the existing LDAP / Azure AD / SAML backends. Works with any OIDC-compliant IdP (Keycloak, Authentik, Okta, Auth0, Google, Entra ID generic mode, etc.) via discovery-driven configuration.

## Changes

**Configuration** — `OIDC_*` settings in `DefaultSettings` and `_ENV_SETTINGS`, including `OIDC_CLIENT_SECRET_FILE` for Docker/Podman secrets.

**Shared helper refactor** — Extract `applyUserMetadata()` from `auth_ldap.py` and `auth_aad.py` into `warp/auth.py`. Removed stray `print(aadGroupMap)`.

**OIDC backend** (`warp/auth_oidc.py`) — Authlib-based redirect flow with:
- Discovery via `.well-known/openid-configuration`
- Auto-provisioning + display name sync
- Group mapping with access-control gate (LDAP semantics)
- Strict group mapping, excluded users, optional UserInfo call
- PKCE, RP-initiated logout, `OIDC_HTTPS_SCHEME`

**Templates** — `auth_error.html` (shared with AAD), conditional SSO button in `login.html`.

**i18n** — `btn.Sign in with SSO`, `Logout`, `Bookings`, `Authentication error`, and auth error messages in all 5 languages.

**Docs** — Full OIDC section in CONFIGURATION.md (variable tables, redirect URI, Keycloak example), §1.5 + §27.4 in FEATURES.md, Azure AD + OIDC in README.md. Corrected the incorrect "all SSO providers support excluded users" claim.

**Containers** — Commented OIDC config in quadlet and compose files, `oidc_client_secret.txt` in secrets README.

**Tests** — 12 unit tests for `oidcGetUserMetadata` claim mapping.

## Test plan

- [x] Unit tests pass (`python -m pytest tests/`)
- [x] All auth modules import cleanly
- [x] Manually tested against Keycloak: alice (allowed group) → login ✅, bob (no allowed group) → access denied ✅, admin (excluded user) → local password ✅
- [x] RP-initiated logout clears Keycloak session
- [x] Built-in auth and LDAP unaffected by the `applyUserMetadata` refactor

Co-Authored-By: GLM-5.1 <glm-5.1@z.ai>