### PR TITLE
SAML: mod_auth_mellon parity (metadata file, endpoint path, session cookie)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -778,12 +778,30 @@ endpoint, signed assertion / signed AuthnRequest support.
 | default value: | `None` (must be defined)                                                                       |
 | description:   | SP entity ID (issuer). Typically `https://<host>/saml/metadata`.                                |
 
+| variable:      | `SAML_ENDPOINT_PATH`                                                                                       |
+| :------------- | :-------------------------------------------------------------------------------------------------------- |
+| type:          | `string`                                                                                                  |
+| default value: | `/saml`                                                                                                   |
+| description:   | Base path under which the SP endpoints are mounted (ACS `<path>/acs`, SLS `<path>/sls`, metadata `<path>/metadata`, SSO-start `<path>/login`). Equivalent to Mellon's `MellonEndpointPath`. `/login` and `/logout` always stay at the root. |
+
 | variable:      | `SAML_IDP_METADATA_URL`                                                                                  |
 | :------------- | :-------------------------------------------------------------------------------------------------------|
 | type:          | `string`                                                                                                |
 | default value: | `None`                                                                                                  |
 | description:   | IdP metadata URL. WARP auto-loads the IdP entity ID, SSO URL, SLO URL, and signing certificate. Prefer this over manual configuration. |
 | example:       | Keycloak: `https://idp.example.org/realms/warp/protocol/saml/descriptor`                                 |
+
+| variable:      | `SAML_IDP_METADATA_FILE`                                                                                  |
+| :------------- | :-------------------------------------------------------------------------------------------------------- |
+| type:          | `string` (file path)                                                                                     |
+| default value: | `None`                                                                                                   |
+| description:   | Path to a local IdP metadata XML file — the same role as Mellon's `MellonIdPMetadataFile`. Use this when the IdP only offers a downloadable metadata file (e.g. Okta) or the WARP host has no egress to fetch `SAML_IDP_METADATA_URL`. The file contents are loaded into `SAML_IDP_METADATA` via the `_FILE` convention. Precedence: `SAML_IDP_METADATA_URL` > file/inline metadata > manual `SAML_IDP_*` fields. |
+
+| variable:      | `SAML_IDP_METADATA`                                                                                       |
+| :------------- | :-------------------------------------------------------------------------------------------------------- |
+| type:          | `string` (XML)                                                                                           |
+| default value: | `None`                                                                                                   |
+| description:   | IdP metadata XML provided inline (alternative to the file/URL). Usually set indirectly via `SAML_IDP_METADATA_FILE`. |
 
 | variable:      | `SAML_IDP_ENTITY_ID`                                            |
 | :------------- | :-------------------------------------------------------------- |
@@ -889,7 +907,8 @@ endpoint, signed assertion / signed AuthnRequest support.
 
 ### SP endpoints
 
-Register the following endpoints at your IdP:
+Register the following endpoints at your IdP (the `/saml` base path is
+[`SAML_ENDPOINT_PATH`](#configuration-variables-6), shown here at its default):
 
 | Endpoint       | URL                                        | Binding       |
 | --------------- | ------------------------------------------ | ------------- |
@@ -903,6 +922,41 @@ listens on `http`, because the proxy rewrites the scheme.
 
 You can also point your IdP to `https://<host>/saml/metadata` to auto-load the
 SP metadata XML (entity ID, ACS URL, SLS URL, SP certificate).
+
+### Session cookie and the SAML POST binding
+
+The IdP returns the assertion as a **cross-site POST** to the ACS endpoint, so
+the browser must include WARP's session cookie on that POST for RelayState and
+replay (`InResponseTo`) protection to work. Flask's default makes the cookie
+`SameSite=Lax`, which browsers do **not** send on cross-site POSTs. For SAML,
+set the cookie to `SameSite=None; Secure` — the native equivalent of Mellon's
+`MellonCookieSameSite none` / `MellonSecureCookie On`:
+
+```
+WARP_SESSION_COOKIE_SAMESITE=None
+WARP_SESSION_COOKIE_SECURE=true
+```
+
+`SameSite=None` **requires** `Secure`, so WARP must be served over HTTPS. If you
+leave the default `Lax`, SSO still works but falls back to the unsolicited path
+(no `InResponseTo` validation, unreliable RelayState).
+
+### Migrating from `mod_auth_mellon`
+
+| Mellon directive            | Native SAML setting |
+| --------------------------- | ------------------- |
+| `MellonEnable auth`         | `WARP_AUTH_SAML=true` |
+| `MellonUser "uid"`          | `WARP_SAML_LOGIN_ATTRIBUTE=uid` (omit / leave empty to use the NameID) |
+| `MellonSPPrivateKeyFile`    | `WARP_SAML_SP_PRIVATE_KEY_FILE` |
+| `MellonSPCertFile`          | `WARP_SAML_SP_X509_CERT_FILE` |
+| `MellonIdPMetadataFile`     | `WARP_SAML_IDP_METADATA_FILE` (or `WARP_SAML_IDP_METADATA_URL`) |
+| `MellonEndpointPath /sp`    | `WARP_SAML_ENDPOINT_PATH=/sp` |
+| `MellonSecureCookie On`     | `WARP_SESSION_COOKIE_SECURE=true` |
+| `MellonCookieSameSite none` | `WARP_SESSION_COOKIE_SAMESITE=None` |
+
+Note the SP endpoint paths differ from Mellon's: the ACS is `<path>/acs` (not
+`<path>/postResponse`) and SLS is `<path>/sls`, so re-register the SP at your IdP
+(easiest: import `https://<host>/saml/metadata`).
 
 ### Secret `_FILE` convention
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -819,8 +819,10 @@ Any setting can be provided as an environment variable with the `WARP_` prefix (
 | Setting                      | Default              | Description                                  |
 |------------------------------|----------------------|----------------------------------------------|
 | `AUTH_SAML`                  | unset                | Set to `true` to enable native SAML auth     |
+| `SAML_ENDPOINT_PATH`         | `/saml`              | Base path for SP endpoints (Mellon `MellonEndpointPath`) |
 | `SAML_SP_ENTITY_ID`          | —                    | SP entity ID (issuer)                        |
 | `SAML_IDP_METADATA_URL`      | unset                | IdP metadata URL (auto-discovery)             |
+| `SAML_IDP_METADATA_FILE`     | unset                | Local IdP metadata XML file (→ `SAML_IDP_METADATA`) |
 | `SAML_IDP_ENTITY_ID`         | unset                | Manual IdP entity ID                          |
 | `SAML_IDP_SSO_URL`           | unset                | Manual IdP SSO URL                            |
 | `SAML_IDP_SLO_URL`           | unset                | Manual IdP SLO URL                            |
@@ -838,3 +840,9 @@ Any setting can be provided as an environment variable with the `WARP_` prefix (
 | `SAML_AUTHN_REQUESTS_SIGNED` | `false`              | Sign outgoing AuthnRequests                    |
 | `SAML_WANT_ASSERTIONS_SIGNED`| `true`               | Require signed assertions from the IdP        |
 | `SAML_WANT_MESSAGES_SIGNED`  | `false`              | Require signed SAML messages from the IdP     |
+
+> The IdP delivers the assertion via a cross-site POST to the ACS endpoint. For
+> RelayState and `InResponseTo` validation to work in browsers, set
+> `WARP_SESSION_COOKIE_SAMESITE=None` and `WARP_SESSION_COOKIE_SECURE=true`
+> (HTTPS required) — the native equivalent of Mellon's `MellonCookieSameSite none`.
+> See [CONFIGURATION.md](CONFIGURATION.md#session-cookie-and-the-saml-post-binding).

--- a/containers/compose/compose.yaml
+++ b/containers/compose/compose.yaml
@@ -30,8 +30,15 @@ services:
       # WARP_AUTH_SAML: 'true'
       # WARP_SAML_SP_ENTITY_ID: 'https://warp.example.org/saml/metadata'
       # WARP_SAML_IDP_METADATA_URL: 'https://idp.example.org/realms/warp/protocol/saml/descriptor'
+      # # Or a downloadable IdP metadata file (e.g. Okta):
+      # WARP_SAML_IDP_METADATA_FILE: /etc/warp/idp-metadata.xml
       # WARP_SAML_SP_PRIVATE_KEY_FILE: /run/secrets/warp_saml_sp_private_key
       # WARP_SAML_GROUP_MAP: '[ ["warp-allowed", null], [null, "Everyone"] ]'
+      # # Optional custom SP endpoint base path (default /saml):
+      # WARP_SAML_ENDPOINT_PATH: /saml
+      # # Required for the IdP→ACS cross-site POST (SameSite=None needs Secure/HTTPS):
+      # WARP_SESSION_COOKIE_SAMESITE: 'None'
+      # WARP_SESSION_COOKIE_SECURE: 'true'
     secrets:
       - warp_db_password
       - warp_secret_key

--- a/containers/quadlet/warp-app.container
+++ b/containers/quadlet/warp-app.container
@@ -44,9 +44,16 @@ Environment=WARP_LANGUAGE_FILE=i18n/en.js
 # Environment=WARP_AUTH_SAML=true
 # Environment=WARP_SAML_SP_ENTITY_ID=https://warp.example.org/saml/metadata
 # Environment=WARP_SAML_IDP_METADATA_URL=https://idp.example.org/realms/warp/protocol/saml/descriptor
+# Or, for IdPs that only offer a downloadable metadata file (e.g. Okta):
+# Environment=WARP_SAML_IDP_METADATA_FILE=/etc/warp/idp-metadata.xml
 # Secret=warp-saml-sp-private-key,type=env,target=WARP_SAML_SP_PRIVATE_KEY
 # Environment=WARP_SAML_GROUPS_ATTRIBUTE=groups
 # Environment=WARP_SAML_GROUP_MAP=[ ["warp-allowed", null], [null, "Everyone"] ]
+# Optional: custom SP endpoint base path (default /saml)
+# Environment=WARP_SAML_ENDPOINT_PATH=/saml
+# Required for the IdP→ACS cross-site POST (SameSite=None needs Secure/HTTPS):
+# Environment=WARP_SESSION_COOKIE_SAMESITE=None
+# Environment=WARP_SESSION_COOKIE_SECURE=true
 # Create the podman secret with: podman secret create warp-saml-sp-private-key <file>
 
 [Install]

--- a/tests/test_saml_config.py
+++ b/tests/test_saml_config.py
@@ -1,0 +1,40 @@
+# Tests for the SAML-related configuration plumbing added for mod_auth_mellon
+# parity: IdP metadata-from-file, session-cookie SameSite/Secure, and the
+# configurable endpoint path.
+
+import flask
+from warp import config
+
+
+def test_idp_metadata_file_loads_into_metadata(tmp_path, monkeypatch):
+    """WARP_SAML_IDP_METADATA_FILE reads the XML into SAML_IDP_METADATA
+    (the _FILE convention), stripping one trailing newline."""
+    f = tmp_path / "idp-metadata.xml"
+    f.write_text("<EntityDescriptor>meta</EntityDescriptor>\n")
+    # isolate: only our var should be read
+    for k in list(__import__('os').environ):
+        if k.startswith('WARP_'):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("WARP_SAML_IDP_METADATA_FILE", str(f))
+
+    app = flask.Flask(__name__)
+    config.readEnvironmentSettings(app)
+
+    assert app.config['SAML_IDP_METADATA'] == "<EntityDescriptor>meta</EntityDescriptor>"
+    assert 'SAML_IDP_METADATA_FILE' not in app.config
+
+
+def test_session_cookie_settings_registered():
+    assert config._ENV_SETTINGS['SESSION_COOKIE_SAMESITE'] is config._fmt_str
+    assert config._ENV_SETTINGS['SESSION_COOKIE_SECURE'] is config._fmt_bool
+
+
+def test_saml_endpoint_and_metadata_settings_registered():
+    assert config._ENV_SETTINGS['SAML_ENDPOINT_PATH'] is config._fmt_str
+    assert config._ENV_SETTINGS['SAML_IDP_METADATA'] is config._fmt_str
+    assert config._ENV_SETTINGS['SAML_IDP_METADATA_FILE'] is config._fmt_file
+
+
+def test_endpoint_path_default():
+    from warp.config import DefaultSettings
+    assert DefaultSettings.SAML_ENDPOINT_PATH == "/saml"

--- a/tests/test_saml_routes.py
+++ b/tests/test_saml_routes.py
@@ -1,0 +1,71 @@
+# Tests for the configurable SAML endpoint path (SAML_ENDPOINT_PATH) and the
+# SSO-button open-redirect guard. These exercise blueprint registration and pure
+# helpers only — no python3-saml / IdP needed.
+
+import flask
+import warp.auth_saml as saml
+
+
+def _rules(app):
+    return {r.endpoint: str(r) for r in app.url_map.iter_rules()}
+
+
+def _app(endpoint_path=None):
+    app = flask.Flask(__name__)
+    if endpoint_path is not None:
+        app.config['SAML_ENDPOINT_PATH'] = endpoint_path
+    app.register_blueprint(saml.bp)
+    return app
+
+
+def test_default_endpoint_path():
+    rules = _rules(_app())
+    assert rules['auth.saml_login'] == '/saml/login'
+    assert rules['auth.saml_acs'] == '/saml/acs'
+    assert rules['auth.saml_metadata'] == '/saml/metadata'
+    assert rules['auth.saml_sls'] == '/saml/sls'
+    # generic entry points stay at the root, like the other backends
+    assert rules['auth.login'] == '/login'
+    assert rules['auth.logout'] == '/logout'
+
+
+def test_custom_endpoint_path():
+    rules = _rules(_app('/sp'))
+    assert rules['auth.saml_acs'] == '/sp/acs'
+    assert rules['auth.saml_sls'] == '/sp/sls'
+    assert rules['auth.saml_metadata'] == '/sp/metadata'
+    assert rules['auth.saml_login'] == '/sp/login'
+    assert rules['auth.login'] == '/login'
+
+
+def test_endpoint_path_normalised():
+    # missing leading slash and trailing slash are tolerated
+    rules = _rules(_app('sp/'))
+    assert rules['auth.saml_acs'] == '/sp/acs'
+
+
+def test_nested_endpoint_path():
+    rules = _rules(_app('/auth/saml'))
+    assert rules['auth.saml_acs'] == '/auth/saml/acs'
+
+
+def test_acs_is_post_only():
+    app = _app()
+    rule = next(r for r in app.url_map.iter_rules() if r.endpoint == 'auth.saml_acs')
+    assert 'POST' in rule.methods
+    assert 'GET' not in rule.methods
+
+
+def test_is_safe_redirect():
+    app = flask.Flask(__name__)
+    with app.test_request_context(base_url="http://localhost:8000/"):
+        assert saml._isSafeRedirect('/') is True
+        assert saml._isSafeRedirect('/bookings') is True
+        assert saml._isSafeRedirect('http://localhost:8000/x') is True
+        # cross-origin and obfuscation attempts are rejected
+        assert saml._isSafeRedirect('https://evil.com/x') is False
+        assert saml._isSafeRedirect('http://evil.com') is False
+        assert saml._isSafeRedirect('//evil.com') is False
+        assert saml._isSafeRedirect('/\\evil.com') is False
+        assert saml._isSafeRedirect('') is False
+        assert saml._isSafeRedirect(None) is False

--- a/warp/auth_saml.py
+++ b/warp/auth_saml.py
@@ -45,21 +45,30 @@ def _buildSamlSettings():
     if sp_key:
         sp_settings['privateKey'] = sp_key
 
-    # Build IdP settings — prefer metadata URL (discovery), fall back to manual
+    # Build IdP settings — prefer metadata (URL, then local file/inline XML),
+    # fall back to manually configured endpoints.
     idp_settings = {}
 
     metadata_url = config.get('SAML_IDP_METADATA_URL')
-    if metadata_url:
+    # SAML_IDP_METADATA holds the IdP metadata XML directly, or is populated from
+    # SAML_IDP_METADATA_FILE via the _FILE convention (parity with Mellon's
+    # MellonIdPMetadataFile; useful when the IdP exposes a downloadable file or
+    # the WARP host has no egress to fetch the URL).
+    metadata_xml = config.get('SAML_IDP_METADATA')
+    if metadata_url or metadata_xml:
         global _idp_metadata_cache
         if _idp_metadata_cache is None:
             from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
-            # Validate the metadata server's TLS cert only when fetching over
-            # HTTPS (independent of SAML_HTTPS_SCHEME, which is about building
-            # external SP URLs behind a reverse proxy).
-            _idp_metadata_cache = OneLogin_Saml2_IdPMetadataParser.parse_remote(
-                metadata_url,
-                validate_cert=metadata_url.lower().startswith('https'),
-            )
+            if metadata_url:
+                # Validate the metadata server's TLS cert only when fetching over
+                # HTTPS (independent of SAML_HTTPS_SCHEME, which is about building
+                # external SP URLs behind a reverse proxy).
+                _idp_metadata_cache = OneLogin_Saml2_IdPMetadataParser.parse_remote(
+                    metadata_url,
+                    validate_cert=metadata_url.lower().startswith('https'),
+                )
+            else:
+                _idp_metadata_cache = OneLogin_Saml2_IdPMetadataParser.parse(metadata_xml)
         if _idp_metadata_cache:
             idp_settings = _idp_metadata_cache.get('idp', {})
     else:
@@ -214,7 +223,6 @@ def login():
                                  sso_start_url=flask.url_for('.saml_login'))
 
 
-@bp.route('/saml/login')
 def saml_login():
     """Dedicated route for the "Sign in with SSO" button (used when
     SAML_EXCLUDED_USERS is non-empty and the local form is shown).
@@ -223,7 +231,6 @@ def saml_login():
     return _start_saml_flow()
 
 
-@bp.route('/saml/acs', methods=['POST'])
 def saml_acs():
     """SAML Assertion Consumer Service — processes the IdP response."""
     config = flask.current_app.config
@@ -285,7 +292,6 @@ def saml_acs():
     return flask.redirect(app_root_uri)
 
 
-@bp.route('/saml/metadata')
 def saml_metadata():
     """Serve the SP metadata XML so admins can register the SP at the IdP."""
     from onelogin.saml2.settings import OneLogin_Saml2_Settings
@@ -306,7 +312,6 @@ def saml_metadata():
         return "Could not generate SP metadata", 500
 
 
-@bp.route('/saml/sls')
 def saml_sls():
     """SAML Single Logout Service — processes the IdP logout response/request."""
     from onelogin.saml2.auth import OneLogin_Saml2_Auth
@@ -356,6 +361,7 @@ def logout():
 
     # If the IdP has an SLO endpoint, try SP-initiated SLO
     slo_configured = (config.get('SAML_IDP_METADATA_URL')
+                      or config.get('SAML_IDP_METADATA')
                       or config.get('SAML_IDP_SLO_URL'))
 
     if slo_configured:
@@ -387,3 +393,21 @@ def logout():
 
 bp.route('/logout')(logout)
 bp.before_app_request(warp.auth.session)
+
+
+# The SP endpoints (ACS / SLS / metadata / SSO-start) live under a configurable
+# base path (SAML_ENDPOINT_PATH, default "/saml") — parity with Mellon's
+# MellonEndpointPath. They are registered at blueprint-registration time so the
+# path can come from config. Endpoint names stay stable, so url_for('.saml_acs')
+# etc. resolve regardless of the configured path. /login and /logout remain at
+# the root, like the other auth backends.
+def _registerSamlEndpoints(state):
+    base = '/' + state.app.config.get('SAML_ENDPOINT_PATH', '/saml').strip('/')
+    state.add_url_rule(f'{base}/login', endpoint='saml_login', view_func=saml_login)
+    state.add_url_rule(f'{base}/acs', endpoint='saml_acs', view_func=saml_acs,
+                       methods=['POST'])
+    state.add_url_rule(f'{base}/metadata', endpoint='saml_metadata',
+                       view_func=saml_metadata)
+    state.add_url_rule(f'{base}/sls', endpoint='saml_sls', view_func=saml_sls)
+
+bp.record(_registerSamlEndpoints)

--- a/warp/config.py
+++ b/warp/config.py
@@ -97,6 +97,7 @@ class DefaultSettings(object):
     SAML_AUTHN_REQUESTS_SIGNED = False
     SAML_WANT_ASSERTIONS_SIGNED = True
     SAML_WANT_MESSAGES_SIGNED = False
+    SAML_ENDPOINT_PATH = "/saml"
 
     ### LDAP variables to be configured
     # AUTH_LDAP = True
@@ -117,8 +118,10 @@ class DefaultSettings(object):
     # AUTH_SAML = True
     # SAML_SP_ENTITY_ID = "https://warp.example.org/saml/metadata"
     # SAML_IDP_METADATA_URL = "https://idp.example.org/realms/warp/protocol/saml/descriptor"
+    # SAML_IDP_METADATA_FILE = "/etc/warp/idp-metadata.xml"  (local file alternative to the URL)
     # SAML_IDP_ENTITY_ID, SAML_IDP_SSO_URL, SAML_IDP_SLO_URL, SAML_IDP_X509_CERT
     # SAML_SP_X509_CERT, SAML_SP_PRIVATE_KEY
+    # SAML_ENDPOINT_PATH (defaults to /saml; SP endpoints live under it)
 
     # these settings are available, but should not have default value
     # set them up in DevelopmentSettings or via environment
@@ -235,6 +238,9 @@ _ENV_SETTINGS = {
     "MAX_REPORT_ROWS":            _fmt_int,
     "MIN_PASSWORD_LENGTH":        _fmt_int,
     "LOGIN_IGNORECASE":           _fmt_bool,
+    # session cookie (Flask-native; relevant to SAML POST binding, see CONFIGURATION.md)
+    "SESSION_COOKIE_SAMESITE":    _fmt_str,
+    "SESSION_COOKIE_SECURE":      _fmt_bool,
     # database
     "DATABASE_ADDRESS":           _fmt_str,
     "DATABASE_NAME":              _fmt_str,
@@ -253,8 +259,11 @@ _ENV_SETTINGS = {
     "AUTH_OIDC":                  _fmt_bool,
     # SAML (native)
     "AUTH_SAML":                  _fmt_bool,
+    "SAML_ENDPOINT_PATH":         _fmt_str,
     "SAML_SP_ENTITY_ID":          _fmt_str,
     "SAML_IDP_METADATA_URL":      _fmt_str,
+    "SAML_IDP_METADATA":          _fmt_str,
+    "SAML_IDP_METADATA_FILE":     _fmt_file,
     "SAML_IDP_ENTITY_ID":         _fmt_str,
     "SAML_IDP_SSO_URL":           _fmt_str,
     "SAML_IDP_SLO_URL":           _fmt_str,


### PR DESCRIPTION
Follow-up to #67. Closes remaining parity gaps with a typical `mod_auth_mellon` deployment.

## Changes

- **`SAML_IDP_METADATA_FILE` / `SAML_IDP_METADATA`** — configure the IdP from a local metadata XML file (or inline), not just a URL. Mirrors `MellonIdPMetadataFile`; needed for IdPs that only expose a downloadable file (e.g. Okta) or hosts with no egress. Precedence: `SAML_IDP_METADATA_URL` > file/inline > manual `SAML_IDP_*`.
- **`SAML_ENDPOINT_PATH`** (default `/saml`) — configurable base path for the SP endpoints (`acs`/`sls`/`metadata`/`login`), mirroring `MellonEndpointPath`. Registered at blueprint-registration time; endpoint names unchanged so `url_for()` still resolves. `/login` and `/logout` stay at the root.
- **`SESSION_COOKIE_SAMESITE` / `SESSION_COOKIE_SECURE`** (Flask-native env settings) — the IdP→ACS cross-site POST needs `SameSite=None; Secure`, the equivalent of `MellonCookieSameSite none` / `MellonSecureCookie On`. Without it, SSO still works but falls back to the unsolicited path (no InResponseTo validation).

## Docs

Per-variable entries, an SP-endpoint + SameSite note, and a **`mod_auth_mellon` → native migration table** in CONFIGURATION.md; FEATURES table and container examples (quadlet/compose) updated.

## Tests

- `tests/test_saml_routes.py` — configurable endpoint path (default, custom, nested, normalised), ACS POST-only, and the RelayState open-redirect guard.
- `tests/test_saml_config.py` — metadata-file `_FILE` plumbing and cookie/endpoint settings registration.
- **54 tests pass.**

## Verification

Re-ran the live Keycloak SAML e2e (alice/bob/carol) on the default path and confirmed a custom `SAML_ENDPOINT_PATH=/sp` serves endpoints under `/sp/*` (and `/saml/*` no longer routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)