### PR TITLE
feat(auth): support comma-separated attributes in AAD_USER_NAME_ATTRIBUTE

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -592,11 +592,11 @@ Features: auto-provisioning, display name sync on every login, same group mappin
 | default value: | `https`                                                                                                                                                              |
 | description:   | Scheme used when constructing the OAuth2 redirect URI sent to Azure. Change to `http` only in local development (Azure requires HTTPS for production redirect URIs). |
 
-| variable:      | `AAD_USER_NAME_ATTRIBUTE`                           |
-| :------------- | :-------------------------------------------------- |
-| type:          | `string`                                            |
-| default value: | `name`                                              |
-| description:   | OIDC claim used as the user's display name in WARP. |
+| variable:      | `AAD_USER_NAME_ATTRIBUTE`                                                                                       |
+| :------------- | :--------------------------------------------------                                                             |
+| type:          | `string`                                                                                                        |
+| default value: | `name` or `given_name,family_name`                                                                              |
+| description:   | OIDC claim used as the user's display name in WARP, supports comma-separated list of attributes to concatenate. |
 
 | variable:      | `AAD_LOGIN_ATTRIBUTE`                                                                                                    |
 | :------------- | :----------------------------------------------------------------------------------------------------------------------- |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -364,11 +364,11 @@ Please note that every variable can be set either in the config file or via the 
 | description:   | LDAP filter for the user lookup. May contain a `{login}` placeholder.               |
 | example:       | OpenLDAP: `(objectClass=*)`<br/>AD: `(&(sAMAccountName={login})(objectClass=user))` |
 
-| variable:      | `LDAP_USER_NAME_ATTRIBUTE`                              |
-| :------------- | :------------------------------------------------------ |
-| type:          | `string`                                                |
-| default value: | `cn`                                                    |
-| description:   | LDAP attribute used as the user's display name in WARP. |
+| variable:      | `LDAP_USER_NAME_ATTRIBUTE`                                                                                                                                                              |
+| :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type:          | `string` or `array of string`                                                                                                                                                          |
+| default value: | `cn`                                                                                                                                                                                    |
+| description:   | LDAP attribute used as the user's display name in WARP. May be a JSON array of attributes (e.g. `["givenName","sn"]`); their values are joined with a space. Falls back to the login when none are present. |
 
 | variable:      | `LDAP_GROUP_SEARCH_BASE`                                                               |
 | :------------- | :------------------------------------------------------------------------------------- |
@@ -511,7 +511,7 @@ WARP_LDAP_EXCLUDED_USERS="['admin']"
 # The following are defaults — shown here for clarity
 WARP_LDAP_STARTTLS="true"
 WARP_LDAP_VALIDATE_CERT="false"
-WARP_LDAP_USER_NAME_ATTRIBUTE="cn"
+WARP_LDAP_USER_NAME_ATTRIBUTE='"cn"'   # or a JSON array, e.g. '["givenName","sn"]'
 WARP_LDAP_GROUP_SEARCH_FILTER_TEMPLATE="(&(memberUid={login})(cn={group}))"
 ```
 
@@ -592,11 +592,11 @@ Features: auto-provisioning, display name sync on every login, same group mappin
 | default value: | `https`                                                                                                                                                              |
 | description:   | Scheme used when constructing the OAuth2 redirect URI sent to Azure. Change to `http` only in local development (Azure requires HTTPS for production redirect URIs). |
 
-| variable:      | `AAD_USER_NAME_ATTRIBUTE`                                                                                       |
-| :------------- | :--------------------------------------------------                                                             |
-| type:          | `string`                                                                                                        |
-| default value: | `name` or `given_name,family_name`                                                                              |
-| description:   | OIDC claim used as the user's display name in WARP, supports comma-separated list of attributes to concatenate. |
+| variable:      | `AAD_USER_NAME_ATTRIBUTE`                                                                                                                                                              |
+| :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type:          | `string` or `array of string`                                                                                                                                                          |
+| default value: | `name`                                                                                                                                                                                  |
+| description:   | OIDC claim used as the user's display name in WARP. May be a JSON array of claims (e.g. `["given_name","family_name"]`); their values are joined with a space. Falls back to the login when none are present. |
 
 | variable:      | `AAD_LOGIN_ATTRIBUTE`                                                                                                    |
 | :------------- | :----------------------------------------------------------------------------------------------------------------------- |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -775,7 +775,7 @@ Any setting can be provided as an environment variable with the `WARP_` prefix (
 | `LDAP_TLS_VERSION` / `LDAP_TLS_CIPHERS` | unset                           | Optional TLS protocol version and cipher list        |
 | `LDAP_USER_TEMPLATE`                 | —                                  | Bind DN template, e.g. `uid={login},ou=users,…`      |
 | `LDAP_USER_SEARCH_BASE`              | unset                              | Search base for user lookup (falls back to template) |
-| `LDAP_USER_NAME_ATTRIBUTE`           | `cn`                               | Attribute used as the display name                   |
+| `LDAP_USER_NAME_ATTRIBUTE`           | `cn`                               | Attribute(s) used as the display name; a JSON array joins several |
 | `LDAP_USER_SEARCH_FILTER_TEMPLATE`   | `(objectClass=person)`             | Filter for the user lookup                           |
 | `LDAP_GROUP_SEARCH_BASE`             | unset                              | Search base for group membership checks              |
 | `LDAP_GROUP_SEARCH_FILTER_TEMPLATE`  | `(&(memberUid={login})(cn={group}))` | Filter for group membership checks                 |
@@ -793,7 +793,7 @@ Any setting can be provided as an environment variable with the `WARP_` prefix (
 | `AAD_CLIENT_SECRET`        | —                    | OAuth2 client secret                         |
 | `AAD_HTTPS_SCHEME`         | `https`              | Scheme used for the redirect URI             |
 | `AAD_LOGIN_ATTRIBUTE`      | `preferred_username` | Claim used as the WARP login                 |
-| `AAD_USER_NAME_ATTRIBUTE`  | `name`               | Claim used as the display name               |
+| `AAD_USER_NAME_ATTRIBUTE`  | `name`               | Claim(s) used as the display name; a JSON array joins several |
 | `AAD_GROUP_MAP`            | `[[null, null]]`     | Same semantics as `LDAP_GROUP_MAP`           |
 | `AAD_GROUP_STRICT_MAPPING` | `false`              | Same semantics as `LDAP_GROUP_STRICT_MAPPING`|
 

--- a/warp/auth_aad.py
+++ b/warp/auth_aad.py
@@ -78,13 +78,18 @@ def signin_oidc():
 	return flask.redirect(app_root_uri)
 
 def aadGetUserMetadata(userData):
+	login = userData[flask.current_app.config.get('AAD_LOGIN_ATTRIBUTE')]
+
+	# AAD_USER_NAME_ATTRIBUTE is a single claim name or a list of them; join the
+	# claims that are present, falling back to the login when none resolve.
+	nameAttrs = flask.current_app.config.get('AAD_USER_NAME_ATTRIBUTE')
+	if isinstance(nameAttrs, str):
+		nameAttrs = [nameAttrs]
+	userName = ' '.join(str(userData[a]) for a in nameAttrs if a in userData) or login
+
 	ret = {
-		'login': userData[flask.current_app.config.get('AAD_LOGIN_ATTRIBUTE')],
-		'userName': ' '.join(
-		    userData[attr]
-		    for attr in flask.current_app.config.get('AAD_USER_NAME_ATTRIBUTE').split(',')
-		    if attr.strip() in userData
-		),
+		'login': login,
+		'userName': userName,
 		'groups': [],
 	}
 

--- a/warp/auth_aad.py
+++ b/warp/auth_aad.py
@@ -80,7 +80,11 @@ def signin_oidc():
 def aadGetUserMetadata(userData):
 	ret = {
 		'login': userData[flask.current_app.config.get('AAD_LOGIN_ATTRIBUTE')],
-		'userName': userData[flask.current_app.config.get('AAD_USER_NAME_ATTRIBUTE')],
+		'userName': ' '.join(
+		    userData[attr]
+		    for attr in flask.current_app.config.get('AAD_USER_NAME_ATTRIBUTE').split(',')
+		    if attr.strip() in userData
+		),
 		'groups': [],
 	}
 

--- a/warp/auth_ldap.py
+++ b/warp/auth_ldap.py
@@ -88,7 +88,11 @@ def ldapGetUserMetadata(login,ldapConnection):
     userSearchFilter = flask.current_app.config.get("LDAP_USER_SEARCH_FILTER_TEMPLATE","")
     userSearchFilter = userSearchFilter.format(login=escape_rdn(login))
 
+    # LDAP_USER_NAME_ATTRIBUTE is a single attribute name or a list of them; we
+    # request them all and join the ones present on the entry below.
     ldapNameAtt = flask.current_app.config.get('LDAP_USER_NAME_ATTRIBUTE')
+    if isinstance(ldapNameAtt, str):
+        ldapNameAtt = [ldapNameAtt]
     ldapConnection.search(search_base=userSearchBase,
                           search_filter=userSearchFilter,
                           attributes=ldapNameAtt)
@@ -96,9 +100,13 @@ def ldapGetUserMetadata(login,ldapConnection):
     if len(ldapConnection.entries) != 1:
         raise Exception(f"LDAP: Wrong number of enties returned for the user: {len(ldapConnection.entries)}")
 
+    entry = ldapConnection.entries[0]
+    # Join the attributes that are present, falling back to the login when none
+    # resolve (consistent with the OIDC/SAML backends).
+    userName = ' '.join(str(entry[a].value) for a in ldapNameAtt if a in entry) or login
 
     ret = {
-        "userName": ldapConnection.entries[0][ldapNameAtt].value,
+        "userName": userName,
         "groups": []
     }
 

--- a/warp/config.py
+++ b/warp/config.py
@@ -211,6 +211,8 @@ def _fmt_file(v):
 
 # JSON shapes for the collection-valued settings.
 _ARRAY_OF_STRINGS = {"type": "array", "items": {"type": "string"}}
+# A single claim/attribute name, or a JSON array of them to concatenate.
+_STRING_OR_ARRAY_OF_STRINGS = {"type": ["string", "array"], "items": {"type": "string"}}
 _ARRAY_OF_WEEKDAYS = {"type": "array", "items": {"type": "integer", "minimum": 0, "maximum": 6}}
 _GROUP_MAP = {  # list of [source_group_or_null, warp_group_or_null] pairs
     "type": "array",
@@ -292,7 +294,7 @@ _ENV_SETTINGS = {
     "LDAP_TLS_VERSION":           _fmt_str,
     "LDAP_TLS_CIPHERS":           _fmt_str,
     "LDAP_USER_TEMPLATE":         _fmt_str,
-    "LDAP_USER_NAME_ATTRIBUTE":   _fmt_str,
+    "LDAP_USER_NAME_ATTRIBUTE":   _fmt_json(_STRING_OR_ARRAY_OF_STRINGS),
     "LDAP_USER_SEARCH_BASE":      _fmt_str,
     "LDAP_USER_SEARCH_FILTER_TEMPLATE":  _fmt_str,
     "LDAP_GROUP_SEARCH_BASE":     _fmt_str,
@@ -305,7 +307,7 @@ _ENV_SETTINGS = {
     "AAD_CLIENT_ID":              _fmt_str,
     "AAD_CLIENT_SECRET":          _fmt_str,
     "AAD_HTTPS_SCHEME":           _fmt_str,
-    "AAD_USER_NAME_ATTRIBUTE":    _fmt_str,
+    "AAD_USER_NAME_ATTRIBUTE":    _fmt_json(_STRING_OR_ARRAY_OF_STRINGS),
     "AAD_LOGIN_ATTRIBUTE":        _fmt_str,
     "AAD_GROUP_MAP":              _fmt_json(_GROUP_MAP),
     "AAD_GROUP_STRICT_MAPPING":   _fmt_bool,


### PR DESCRIPTION
## Problem

Azure AD does not always expose a pre-formatted `name` claim.
In many tenant configurations, the full name is split across two
separate claims: `given_name` and `family_name`.

The current implementation passes `AAD_USER_NAME_ATTRIBUTE` directly
as a single dictionary key, so it is impossible to combine multiple
claims into one display name without customising the token in Azure.

## Solution

Allow `AAD_USER_NAME_ATTRIBUTE` to accept a comma-separated list of
claim names. When multiple attributes are provided, their values are
joined with a space to produce the full display name.

Example configuration:

    WARP_AAD_USER_NAME_ATTRIBUTE=given_name,family_name

This is fully backward-compatible: existing configurations using a
single attribute (e.g. `name`) continue to work unchanged.

## Changes

- `warp/auth_aad.py`: `aadGetUserMetadata` now splits
  `AAD_USER_NAME_ATTRIBUTE` on commas and joins the resolved values.
- `README.md`: updated the `AAD_USER_NAME_ATTRIBUTE` description to
  document the comma-separated syntax.