### PR TITLE
feat(editor): marquee border-grip drag, seat name focus, add-mode layout, placeholder select-all

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -205,6 +205,7 @@ Accessible via the map icon on the Plans management page.
 - Multi-seat selection with a marquee: drag to select multiple seats, then move or transform them together.
 - To move all selected seats, **grab the marquee border** (the dashed outline) and drag. Clicking inside the box interior does not initiate a move — but it does keep the selection (the marquee stays visible). The border has an enlarged grip area so it is easy to grab.
 - The cursor changes to `move` only when hovering over the border, signalling where to grab.
+- When a seat is selected or newly added, the **Seat name** field is focused automatically so it can be named right away (a new seat's placeholder name is pre-selected, so typing replaces it).
 - The selected group shows a transform box with **8 resize handles** (4 corners + 4 edges) and a **rotation handle**.
 - Scaling and rotation pivot around the group's center — unless the currently selected seat is part of the group, in which case it stays **locked in place** and acts as the pivot.
 - While rotating, the selection box and handles are hidden and replaced by a **rotation guide**: a marker on the pivot, a dashed line from the pivot to the cursor, and a live **angle readout** next to the cursor. Rotation is free (no angle snapping), so seats can be aligned to maps that are not axis-aligned.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -203,6 +203,8 @@ Accessible via the map icon on the Plans management page.
 ### 4.3 Editing Seats
 - Select a seat to edit its name, position (X/Y), or drag it to a new position.
 - Multi-seat selection with a marquee: drag to select multiple seats, then move or transform them together.
+- To move all selected seats, **grab the marquee border** (the dashed outline) and drag. Clicking inside the box interior does not initiate a move — but it does keep the selection (the marquee stays visible). The border has an enlarged grip area so it is easy to grab.
+- The cursor changes to `move` only when hovering over the border, signalling where to grab.
 - The selected group shows a transform box with **8 resize handles** (4 corners + 4 edges) and a **rotation handle**.
 - Scaling and rotation pivot around the group's center — unless the currently selected seat is part of the group, in which case it stays **locked in place** and acts as the pivot.
 - While rotating, the selection box and handles are hidden and replaced by a **rotation guide**: a marker on the pivot, a dashed line from the pivot to the cursor, and a live **angle readout** next to the cursor. Rotation is free (no angle snapping), so seats can be aligned to maps that are not axis-aligned.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -205,7 +205,7 @@ Accessible via the map icon on the Plans management page.
 - Multi-seat selection with a marquee: drag to select multiple seats, then move or transform them together.
 - To move all selected seats, **grab the marquee border** (the dashed outline) and drag. Clicking inside the box interior does not initiate a move — but it does keep the selection (the marquee stays visible). The border has an enlarged grip area so it is easy to grab.
 - The cursor changes to `move` only when hovering over the border, signalling where to grab.
-- When a seat is selected or newly added, the **Seat name** field is focused automatically so it can be named right away (a new seat's placeholder name is pre-selected, so typing replaces it).
+- When a seat is selected or newly added, the **Seat name** field is focused automatically. A new seat's auto-generated placeholder name stays fully selected (so typing replaces it) until you actually edit the name — including across re-selections. Once the name has been edited, or for existing seats, the caret is placed at the end for normal editing.
 - The selected group shows a transform box with **8 resize handles** (4 corners + 4 edges) and a **rotation handle**.
 - Scaling and rotation pivot around the group's center — unless the currently selected seat is part of the group, in which case it stays **locked in place** and acts as the pivot.
 - While rotating, the selection box and handles are hidden and replaced by a **rotation guide**: a marker on the pivot, a dashed line from the pivot to the cursor, and a live **angle readout** next to the cursor. Rotation is free (no angle snapping), so seats can be aligned to maps that are not axis-aligned.

--- a/e2e/tests/zone-admin/zone-editor.spec.ts
+++ b/e2e/tests/zone-admin/zone-editor.spec.ts
@@ -154,6 +154,14 @@ test.describe('selecting and editing a seat', () => {
     expect(Number(result.rows[0].y)).toBe(newY);
   });
 
+  test('selecting a seat focuses the name field', async ({ page }) => {
+    await logIn(page, ADMIN);
+    const [seat] = await getZoneSeats(ZID);
+    await openEditor(page);
+    await selectSeat(page, seat);
+    await expect(page.locator('#seat_name')).toBeFocused();
+  });
+
 });
 
 // ─── Delete ───────────────────────────────────────────────────────────────────
@@ -281,6 +289,40 @@ test.describe('adding a seat', () => {
     const modal = page.locator('.modal.open', { hasText: /update the plan/ });
     await expect(modal).toContainText('added one seat');
     await modal.locator('a', { hasText: /No/i }).click();
+  });
+
+  test('adding a seat focuses the name field for immediate typing', async ({ page }) => {
+    await logIn(page, ADMIN);
+    await openEditor(page);
+
+    await toggleMode(page);                                  // → Add mode
+    await page.locator('#zone_map').click({ position: EMPTY_SPOT });
+
+    await expect(page.locator('#seat_edit_panel')).toBeVisible();
+    await expect(page.locator('#seat_name')).toBeFocused();
+
+    // Placeholder text is selected → typing replaces it (no manual clear).
+    await page.keyboard.type('TypedName');
+    await expect(page.locator('#seat_name')).toHaveValue('TypedName');
+  });
+
+  test('add mode keeps the edit panel directly below the zone dropdown', async ({ page }) => {
+    await logIn(page, ADMIN);
+    await openEditor(page);
+
+    await toggleMode(page);                                  // → Add mode
+    await page.locator('#zone_map').click({ position: EMPTY_SPOT });
+    await expect(page.locator('#seat_edit_panel')).toBeVisible();
+
+    const dropdown = await page.locator('#add_seat_zone_selector').boundingBox();
+    const panel = await page.locator('#seat_edit_panel').boundingBox();
+    expect(dropdown).not.toBeNull();
+    expect(panel).not.toBeNull();
+
+    // The panel should start just below the dropdown, not floating in the middle.
+    const gap = panel!.y - (dropdown!.y + dropdown!.height);
+    expect(gap).toBeGreaterThanOrEqual(0);
+    expect(gap).toBeLessThanOrEqual(40);   // tolerance for normal margins/padding
   });
 
 });

--- a/e2e/tests/zone-admin/zone-editor.spec.ts
+++ b/e2e/tests/zone-admin/zone-editor.spec.ts
@@ -406,13 +406,18 @@ test.describe('marquee transform and rotation', () => {
     await logIn(page, ADMIN);
     const seats = await getZoneSeats(ZID);
     await openEditor(page);
-    const map = await mapOrigin(page);
 
-    // EMPTY_SPOT is inside the group bounds but not on any seat sprite
-    const from = { x: map.x + EMPTY_SPOT.x, y: map.y + EMPTY_SPOT.y };
-    await page.mouse.move(from.x, from.y);
+    // Drag from a point on the marquee border (top edge, 25% across) — clear of
+    // the nw/ne corner handles and the centred 'n' edge handle. Page coords
+    // from the DOM box, so no map-origin offset is needed.
+    const boxEl = page.locator('.zone_modify_marquee_box');
+    const box = await boxEl.boundingBox();
+    expect(box).not.toBeNull();
+    const borderPoint = { x: box!.x + box!.width * 0.25, y: box!.y };
+
+    await page.mouse.move(borderPoint.x, borderPoint.y);
     await page.mouse.down();
-    await page.mouse.move(from.x + 20, from.y + 15, { steps: 5 });
+    await page.mouse.move(borderPoint.x + 20, borderPoint.y + 15, { steps: 5 });
     await page.mouse.up();
 
     await saveAndConfirm(page);
@@ -422,6 +427,36 @@ test.describe('marquee transform and rotation', () => {
       const a = after.find((t) => t.id === s.id)!;
       expect(Math.abs(a.x - (s.x + 20))).toBeLessThanOrEqual(1);
       expect(Math.abs(a.y - (s.y + 15))).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test('clicking inside the marquee interior keeps the selection and does not move seats', async ({ page }) => {
+    await logIn(page, ADMIN);
+    const seats = await getZoneSeats(ZID);
+    await openEditor(page);
+    const map = await mapOrigin(page);
+
+    // EMPTY_SPOT is inside the group bounds but not on any seat sprite — i.e. an
+    // interior point of the marquee. After the border-grip change, clicking
+    // here must NOT start a move and must NOT clear the selection.
+    const spot = { x: map.x + EMPTY_SPOT.x, y: map.y + EMPTY_SPOT.y };
+    await page.mouse.move(spot.x, spot.y);
+    await page.mouse.down();
+    await page.mouse.move(spot.x + 20, spot.y + 15, { steps: 5 });
+    await page.mouse.up();
+
+    // The marquee (selection) must still be visible — interior clicks suppress
+    // deselection, so the selection is preserved.
+    await expect(page.locator('.zone_modify_marquee_box')).toBeVisible();
+
+    // No save occurred (save button stays disabled — no changes made), so DB
+    // coordinates must be unchanged.
+    await expect(page.locator('#saveBtn')).toHaveClass(/disabled/);
+    const after = await getZoneSeats(ZID);
+    for (const s of seats) {
+      const a = after.find((t) => t.id === s.id)!;
+      expect(a.x).toBe(s.x);
+      expect(a.y).toBe(s.y);
     }
   });
 

--- a/e2e/tests/zone-admin/zone-editor.spec.ts
+++ b/e2e/tests/zone-admin/zone-editor.spec.ts
@@ -325,6 +325,64 @@ test.describe('adding a seat', () => {
     expect(gap).toBeLessThanOrEqual(40);   // tolerance for normal margins/padding
   });
 
+  test('re-selecting a renamed added seat places caret at end, not select-all', async ({ page }) => {
+    await logIn(page, ADMIN);
+    await openEditor(page);
+
+    // Add a seat — first select selects all text (verified by existing test).
+    await toggleMode(page);                                  // → Add mode
+    await page.locator('#zone_map').click({ position: EMPTY_SPOT });
+    await expect(page.locator('#seat_edit_panel')).toBeVisible();
+
+    // Type a name so the placeholder is replaced.
+    await page.keyboard.type('FirstRename');
+
+    // Click an existing seat to deselect the new one.
+    const [existing] = await getZoneSeats(ZID);
+    await selectSeat(page, existing);
+
+    // Click back to the newly added seat. The seat was created at EMPTY_SPOT
+    // (createNewSeat centers the sprite on the click point), so its div center
+    // is at EMPTY_SPOT within the container.
+    await page.locator('#zone_map_container').click({
+      position: { x: EMPTY_SPOT.x, y: EMPTY_SPOT.y },
+    });
+    await expect(page.locator('#seat_edit_panel')).toBeVisible();
+    await expect(page.locator('#seat_name')).toBeFocused();
+
+    // The name was changed from the placeholder, so the caret should be at the
+    // end (not select-all). Typing appends; if text were selected it would replace.
+    await page.keyboard.type('X');
+    await expect(page.locator('#seat_name')).toHaveValue('FirstRenameX');
+  });
+
+  test('re-selecting an added seat with unchanged placeholder still selects all text', async ({ page }) => {
+    await logIn(page, ADMIN);
+    await openEditor(page);
+
+    // Add a seat — placeholder name is auto-generated (NEW_x).
+    await toggleMode(page);                                  // → Add mode
+    await page.locator('#zone_map').click({ position: EMPTY_SPOT });
+    await expect(page.locator('#seat_edit_panel')).toBeVisible();
+
+    // Do NOT type anything — leave the placeholder name as-is.
+    // Click an existing seat to deselect the new one.
+    const [existing] = await getZoneSeats(ZID);
+    await selectSeat(page, existing);
+
+    // Click back to the newly added seat.
+    await page.locator('#zone_map_container').click({
+      position: { x: EMPTY_SPOT.x, y: EMPTY_SPOT.y },
+    });
+    await expect(page.locator('#seat_edit_panel')).toBeVisible();
+    await expect(page.locator('#seat_name')).toBeFocused();
+
+    // The name is still the placeholder, so all text should be selected.
+    // Typing replaces the placeholder entirely.
+    await page.keyboard.type('Replaced');
+    await expect(page.locator('#seat_name')).toHaveValue('Replaced');
+  });
+
 });
 
 // ─── Combined changes and summary ─────────────────────────────────────────────

--- a/js/base/style.css
+++ b/js/base/style.css
@@ -646,6 +646,11 @@ INPUT[type="text"] ~ .show_password_btn::after {
     flex: none !important;
 }
 
+#add_seat_zone_selector,
+#add_seat_zone_error {
+    flex: none;
+}
+
 .switch-container {
     display: flex;
     align-items: center;

--- a/js/views/modules/zoneModify_marquee.js
+++ b/js/views/modules/zoneModify_marquee.js
@@ -17,6 +17,7 @@ function MarqueeController(parentDiv, spriteSize) {
     this._createElements();
 }
 
+MarqueeController.BORDER_GRIP_WIDTH = 8; // half-width of the draggable border band on each side of the 2px dashed line
 MarqueeController.CORNER_SIZE    = 10;
 MarqueeController.H_EDGE_W       = 18;
 MarqueeController.H_EDGE_H       = 10;
@@ -324,10 +325,36 @@ MarqueeController.prototype.getHandleAt = function(px, py) {
         return 'rotate';
 
     var br = this._boxRect;
-    if (px >= br.x && px <= br.x + br.w && py >= br.y && py <= br.y + br.h)
+    var bw = MarqueeController.BORDER_GRIP_WIDTH;
+
+    // Only the border band (the ring between the outer inflated rect and the
+    // inner deflated rect) counts as the draggable "box" grip. Points strictly
+    // inside the inner rect (the box interior) return null so that clicking
+    // empty space inside the marquee does NOT start a move.
+    var insideOuter = px >= br.x - bw && px <= br.x + br.w + bw &&
+                      py >= br.y - bw && py <= br.y + br.h + bw;
+    var insideInner = px >= br.x + bw && px <= br.x + br.w - bw &&
+                      py >= br.y + bw && py <= br.y + br.h - bw;
+
+    if (insideOuter && !insideInner)
         return 'box';
 
     return null;
+};
+
+/**
+ * Full-rect containment test (border + interior). Used by the capture-phase
+ * mousedown handler to suppress deselection when the user clicks anywhere
+ * inside the marquee box — including the interior — so that the selection
+ * and marquee stay visible even though an interior click no longer starts a
+ * move (getHandleAt returns null for interior points).
+ */
+MarqueeController.prototype.isInsideBox = function(px, py) {
+    if (!this.active || !this._boxRect)
+        return false;
+    var br = this._boxRect;
+    return px >= br.x && px <= br.x + br.w &&
+           py >= br.y && py <= br.y + br.h;
 };
 
 MarqueeController.prototype.onHandleMouseDown = function(callback) {

--- a/js/views/modules/zoneModify_seat.js
+++ b/js/views/modules/zoneModify_seat.js
@@ -389,6 +389,7 @@ SeatFactory.prototype.createNewSeat = function(name,x,y) {
     };
 
     let seat = this._createSeat(newSid,{});
+    seat.nameChangedFromPlaceholder = false;  // set true when the user edits the name
 
     this._resetSelectionState();
     this.selectedSeat = seat;

--- a/js/views/planModify.js
+++ b/js/views/planModify.js
@@ -417,7 +417,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
         let x = e.clientX - rect.left;
         let y = e.clientY - rect.top;
 
-        if (marquee.getHandleAt(x, y) === 'box')
+        if (marquee.isInsideBox(x, y))
             seatFactory.suppressDeselect = true;
     };
 

--- a/js/views/planModify.js
+++ b/js/views/planModify.js
@@ -353,13 +353,13 @@ document.addEventListener("DOMContentLoaded", function(e) {
         M.updateTextFields();
         seatEditPanel.style.visibility = "visible";
 
-        // Place keyboard focus in the name field so the user can type right away.
-        // For brand-new seats (auto-generated placeholder name) select the text so
-        // typing replaces it; for existing seats just focus (caret at end) to
-        // avoid an accidental overwrite.
+        // Focus the name field so the user can type right away. For new
+        // seats whose name is still the auto-generated placeholder, select-all
+        // so typing replaces it. Once the user has edited the name (or for
+        // existing seats), place the caret at the end for normal editing.
         requestAnimationFrame(() => {
             seatNameEl.focus();
-            if (seat.isNew())
+            if (seat.isNew() && !seat.nameChangedFromPlaceholder)
                 seatNameEl.select();
         });
     });
@@ -539,6 +539,8 @@ document.addEventListener("DOMContentLoaded", function(e) {
             let selSeat = seatFactory.getSelectedSeat();
             if (!selSeat) return;
             selSeat[prop] = e.target.value;
+            if (prop === 'name')
+                selSeat.nameChangedFromPlaceholder = true;
         };
     };
 

--- a/js/views/planModify.js
+++ b/js/views/planModify.js
@@ -352,6 +352,16 @@ document.addEventListener("DOMContentLoaded", function(e) {
         populateZoneSelect(zid !== undefined ? zid : null);
         M.updateTextFields();
         seatEditPanel.style.visibility = "visible";
+
+        // Place keyboard focus in the name field so the user can type right away.
+        // For brand-new seats (auto-generated placeholder name) select the text so
+        // typing replaces it; for existing seats just focus (caret at end) to
+        // avoid an accidental overwrite.
+        requestAnimationFrame(() => {
+            seatNameEl.focus();
+            if (seat.isNew())
+                seatNameEl.select();
+        });
     });
 
     seatFactory.on('unselect', (seat) => {


### PR DESCRIPTION
## Summary

Three layered improvements to the zone-map editor (`/plans/modify/<pid>`):

### 1. Marquee move requires gripping the border, not interior
- Dragging all selected seats is now triggered only by gripping the **marquee border** (the dashed outline), not by clicking inside the box's interior.
- The border has an enlarged grip area (`BORDER_GRIP_WIDTH = 8px` on each side of the 2px line) so it's easy to grab.
- The cursor shows `move` only when hovering over the border grip area.
- Clicking inside the box interior no longer starts a move but **does keep the selection** (the marquee stays visible) via the new `isInsideBox` full-rect test used by the capture-phase mousedown handler.

### 2. Focus seat name on select/add + fix add-mode panel position
- Selecting or adding a seat now focuses the **Seat name** field automatically.
- For a brand-new seat the placeholder name is pre-selected so typing replaces it immediately.
- Fix regression where, in Add-seats mode with a seat selected, the seat-edit panel floated in the vertical middle of the side panel. The add-mode zone dropdown/error containers inherited `flex:auto` from the broad `.zone_modify_sidepanel DIV` rule and grew. They are now `flex:none`, so the edit panel sits directly below the dropdown.

### 3. Select-all name text only while placeholder is unedited
- Re-selecting a previously-added seat whose name **has been edited** places the caret at the end (regular behaviour).
- Re-selecting a previously-added seat whose name is **still the auto-generated placeholder** (`NEW_x`) keeps select-all so typing replaces it.
- Implemented via a `nameChangedFromPlaceholder` boolean flag on the seat, set to `false` in `createNewSeat` and flipped to `true` the moment the user edits the name field.

## Files changed
- `js/views/modules/zoneModify_marquee.js` — `BORDER_GRIP_WIDTH`, border-band `getHandleAt`, `isInsideBox`
- `js/views/modules/zoneModify_seat.js` — `nameChangedFromPlaceholder` flag in `createNewSeat`
- `js/views/planModify.js` — border-grip `containerMousedownCapture`, name focus/select logic, `changeFactory` flag
- `js/base/style.css` — `flex: none` for add-mode containers
- `e2e/tests/zone-admin/zone-editor.spec.ts` — updated + 5 new tests
- `FEATURES.md` — §4.3 documentation updates

## Test results
All 38 zone-editor e2e tests pass.

Co-Authored-by: GLM 5.2 <noreply@anthropic.com>